### PR TITLE
add: FloatSecondsDurationEncoder

### DIFF
--- a/time.go
+++ b/time.go
@@ -13,23 +13,23 @@ type TimeEncoder func(time.Time, TypeEncoder)
 type DurationEncoder func(time.Duration, TypeEncoder)
 
 // RFC3339TimeEncoder encodes the given Time as a string using RFC3339 layout.
-func RFC3339TimeEncoder(t time.Time, m TypeEncoder) {
+func RFC3339TimeEncoder(t time.Time, e TypeEncoder) {
 	var timeBuf [64]byte
 	var b []byte
 	b = timeBuf[:0]
 	b = t.AppendFormat(b, time.RFC3339)
-	m.EncodeTypeUnsafeBytes(noescape(unsafe.Pointer(&b)))
+	e.EncodeTypeUnsafeBytes(noescape(unsafe.Pointer(&b)))
 	runtime.KeepAlive(&b)
 }
 
 // RFC3339NanoTimeEncoder encodes the given Time as a string using
 // RFC3339Nano layout.
-func RFC3339NanoTimeEncoder(t time.Time, m TypeEncoder) {
+func RFC3339NanoTimeEncoder(t time.Time, e TypeEncoder) {
 	var timeBuf [64]byte
 	var b []byte
 	b = timeBuf[:0]
 	b = t.AppendFormat(b, time.RFC3339Nano)
-	m.EncodeTypeUnsafeBytes(noescape(unsafe.Pointer(&b)))
+	e.EncodeTypeUnsafeBytes(noescape(unsafe.Pointer(&b)))
 	runtime.KeepAlive(&b)
 }
 
@@ -47,13 +47,19 @@ func LayoutTimeEncoder(layout string) TimeEncoder {
 
 // UnixNanoTimeEncoder encodes the given Time as a Unix time, the number of
 // of nanoseconds elapsed since January 1, 1970 UTC.
-func UnixNanoTimeEncoder(t time.Time, m TypeEncoder) {
-	m.EncodeTypeInt64(t.UnixNano())
+func UnixNanoTimeEncoder(t time.Time, e TypeEncoder) {
+	e.EncodeTypeInt64(t.UnixNano())
 }
 
 // NanoDurationEncoder encodes the given Duration as a number of nanoseconds.
-func NanoDurationEncoder(d time.Duration, m TypeEncoder) {
-	m.EncodeTypeInt64(int64(d))
+func NanoDurationEncoder(d time.Duration, e TypeEncoder) {
+	e.EncodeTypeInt64(int64(d))
+}
+
+// FloatSecondsDurationEncoder encodes the given Duration to a floating-point
+// number of seconds elapsed.
+func FloatSecondsDurationEncoder(d time.Duration, e TypeEncoder) {
+	e.EncodeTypeFloat64(float64(d) / float64(time.Second))
 }
 
 // StringDurationEncoder encodes the given Duration as a string using

--- a/time_test.go
+++ b/time_test.go
@@ -47,6 +47,14 @@ func TestNanoDurationEncoder(t *testing.T) {
 	assert.EqualValues(t, 66559305941000, enc.result)
 }
 
+func TestFloatSecondsDurationEncoder(t *testing.T) {
+	d := time.Duration(66559305941000)
+	enc := testTypeEncoder{}
+	FloatSecondsDurationEncoder(d, &enc)
+
+	assert.InDelta(t, 66559.305941, enc.result, 0.0000005)
+}
+
 func TestStringDurationEncoder(t *testing.T) {
 	d := time.Duration(66559305941000)
 	enc := testTypeEncoder{}


### PR DESCRIPTION
In some systems it's required to log duration in fractions of a second. Use FloatSecondsDurationEncoder in those cases.