### PR TITLE
refactor: Bag linked list — O(1) With, no field copy

### DIFF
--- a/bag.go
+++ b/bag.go
@@ -1,71 +1,60 @@
 package logf
 
-import (
-	"context"
-	"sync/atomic"
-)
+import "context"
 
-var nextVersion int32
-
-// Bag is an immutable collection of Fields with a version for cache keying.
+// Bag is an immutable linked list of Fields.
+// Each With creates a new node pointing to the parent — O(1), no copies.
 // Bag is safe to share across goroutines.
 type Bag struct {
-	fields  []Field
-	version int32
+	fields []Field
+	parent *Bag
 }
 
 // NewBag creates a new Bag with the given fields.
 func NewBag(fs ...Field) *Bag {
-	return &Bag{
-		fields:  fs,
-		version: atomic.AddInt32(&nextVersion, 1),
-	}
+	return &Bag{fields: fs}
 }
 
 // With returns a new Bag that contains both the existing fields and the
 // given additional fields. The original Bag is not modified.
+// O(1): no field copy, new node points to parent.
 func (b *Bag) With(fs ...Field) *Bag {
-	if b == nil {
-		return NewBag(fs...)
-	}
-
-	merged := make([]Field, len(b.fields)+len(fs))
-	copy(merged, b.fields)
-	copy(merged[len(b.fields):], fs)
-
-	return &Bag{
-		fields:  merged,
-		version: atomic.AddInt32(&nextVersion, 1),
-	}
+	return &Bag{fields: fs, parent: b}
 }
 
-// Fields returns the fields stored in the Bag.
+// Fields returns all fields in the Bag chain, parent-first order.
 func (b *Bag) Fields() []Field {
 	if b == nil {
 		return nil
 	}
-
-	return b.fields
-}
-
-// Version returns the Bag's version, usable as a cache key.
-func (b *Bag) Version() int32 {
-	if b == nil {
-		return 0
+	if b.parent == nil {
+		return b.fields
 	}
 
-	return b.version
+	// Count total fields.
+	n := 0
+	for node := b; node != nil; node = node.parent {
+		n += len(node.fields)
+	}
+
+	// Collect in reverse (child→parent), then reverse to get parent-first.
+	all := make([]Field, n)
+	i := n
+	for node := b; node != nil; node = node.parent {
+		i -= len(node.fields)
+		copy(all[i:], node.fields)
+	}
+
+	return all
 }
 
-// HasField reports whether the Bag contains a field with the given key.
+// HasField reports whether the Bag chain contains a field with the given key.
 func (b *Bag) HasField(key string) bool {
-	if b == nil {
-		return false
-	}
-
-	for i := range b.fields {
-		if b.fields[i].Key == key {
-			return true
+	for node := b; node != nil; node = node.parent {
+		for i := range node.fields {
+			if node.fields[i].Key == key {
+				return true
+			}
 		}
 	}
 

--- a/bag_test.go
+++ b/bag_test.go
@@ -14,14 +14,12 @@ func TestNewBag(t *testing.T) {
 	assert.Equal(t, 2, len(bag.Fields()))
 	assert.Equal(t, "k1", bag.Fields()[0].Key)
 	assert.Equal(t, "k2", bag.Fields()[1].Key)
-	assert.NotZero(t, bag.Version())
 }
 
 func TestNewBagEmpty(t *testing.T) {
 	bag := NewBag()
 
 	assert.Equal(t, 0, len(bag.Fields()))
-	assert.NotZero(t, bag.Version())
 }
 
 func TestBagWith(t *testing.T) {
@@ -36,8 +34,6 @@ func TestBagWith(t *testing.T) {
 	assert.Equal(t, "k1", bag2.Fields()[0].Key)
 	assert.Equal(t, "k2", bag2.Fields()[1].Key)
 
-	// Different versions.
-	assert.NotEqual(t, bag1.Version(), bag2.Version())
 }
 
 func TestBagWithNil(t *testing.T) {
@@ -52,11 +48,6 @@ func TestBagWithNil(t *testing.T) {
 func TestBagFieldsNil(t *testing.T) {
 	var bag *Bag
 	assert.Nil(t, bag.Fields())
-}
-
-func TestBagVersionNil(t *testing.T) {
-	var bag *Bag
-	assert.Equal(t, int32(0), bag.Version())
 }
 
 func TestBagHasField(t *testing.T) {
@@ -80,14 +71,29 @@ func TestBagImmutable(t *testing.T) {
 	assert.Equal(t, 1, len(bag1.Fields()))
 }
 
-func TestBagVersionUnique(t *testing.T) {
+func TestBagLinkedList(t *testing.T) {
 	bag1 := NewBag(String("a", "1"))
-	bag2 := NewBag(String("b", "2"))
-	bag3 := bag1.With(String("c", "3"))
+	bag2 := bag1.With(String("b", "2"))
+	bag3 := bag2.With(String("c", "3"))
 
-	assert.NotEqual(t, bag1.Version(), bag2.Version())
-	assert.NotEqual(t, bag1.Version(), bag3.Version())
-	assert.NotEqual(t, bag2.Version(), bag3.Version())
+	// Each node only has its own fields.
+	assert.Equal(t, 1, len(bag1.Fields()))
+	assert.Equal(t, 2, len(bag2.Fields()))
+	assert.Equal(t, 3, len(bag3.Fields()))
+
+	// Parent-first order.
+	assert.Equal(t, "a", bag3.Fields()[0].Key)
+	assert.Equal(t, "b", bag3.Fields()[1].Key)
+	assert.Equal(t, "c", bag3.Fields()[2].Key)
+}
+
+func TestBagHasFieldLinkedList(t *testing.T) {
+	bag := NewBag(String("a", "1")).With(String("b", "2")).With(String("c", "3"))
+
+	assert.True(t, bag.HasField("a"))
+	assert.True(t, bag.HasField("b"))
+	assert.True(t, bag.HasField("c"))
+	assert.False(t, bag.HasField("d"))
 }
 
 func TestContextWithBag(t *testing.T) {

--- a/entry.go
+++ b/entry.go
@@ -9,11 +9,9 @@ import (
 // Entry holds a single log message and fields.
 type Entry struct {
 	// LoggerBag holds logger-scoped fields (from Logger.With).
-	// Bag.Version() is used as a cache key by encoders.
 	LoggerBag *Bag
 
 	// Bag holds request-scoped fields (from context via ContextWriter).
-	// Bag.Version() is used as a cache key by encoders.
 	Bag *Bag
 
 	// Fields specifies data fields of a log message.

--- a/jsonencoder.go
+++ b/jsonencoder.go
@@ -82,7 +82,7 @@ func (c JSONEncoderConfig) WithDefaults() JSONEncoderConfig {
 // given JSONEncoderConfig.
 var NewJSONEncoder = jsonEncoderGetter(
 	func(cfg JSONEncoderConfig) Encoder {
-		return &jsonEncoder{cfg.WithDefaults(), NewCache(100), nil, 0}
+		return &jsonEncoder{cfg.WithDefaults(), nil, 0}
 	},
 )
 
@@ -90,7 +90,7 @@ var NewJSONEncoder = jsonEncoderGetter(
 // TypeEncoderFactory with the given JSONEncoderConfig.
 var NewJSONTypeEncoderFactory = jsonTypeEncoderFactoryGetter(
 	func(c JSONEncoderConfig) TypeEncoderFactory {
-		return &jsonEncoder{c.WithDefaults(), nil, nil, 0}
+		return &jsonEncoder{c.WithDefaults(), nil, 0}
 	},
 )
 
@@ -108,7 +108,6 @@ func (c jsonTypeEncoderFactoryGetter) Default() TypeEncoderFactory {
 
 type jsonEncoder struct {
 	JSONEncoderConfig
-	cache *Cache
 
 	buf         *Buffer
 	startBufLen int
@@ -154,11 +153,11 @@ func (f *jsonEncoder) Encode(buf *Buffer, e Entry) error {
 		f.EncodeCaller(e.CallerPC, f)
 	}
 
-	// Context fields (request-scoped, cached).
-	f.encodeBagCached(buf, e.Bag)
+	// Context fields (request-scoped).
+	f.encodeBag(e.Bag)
 
-	// Logger's fields (service-scoped, cached).
-	f.encodeBagCached(buf, e.LoggerBag)
+	// Logger's fields (service-scoped).
+	f.encodeBag(e.LoggerBag)
 
 	// Entry's fields.
 	for _, field := range e.Fields {
@@ -171,23 +170,16 @@ func (f *jsonEncoder) Encode(buf *Buffer, e Entry) error {
 	return nil
 }
 
-func (f *jsonEncoder) encodeBagCached(buf *Buffer, bag *Bag) {
-	v := bag.Version()
-	if v == 0 {
+func (f *jsonEncoder) encodeBag(bag *Bag) {
+	if bag == nil {
 		return
 	}
-
-	if bytes, ok := f.cache.Get(v); ok {
-		buf.AppendBytes(bytes)
-	} else {
-		le := buf.Len()
-		for _, field := range bag.Fields() {
-			field.Accept(f)
-		}
-
-		bf := make([]byte, buf.Len()-le)
-		copy(bf, buf.Data[le:])
-		f.cache.Set(v, bf)
+	// Walk parent first to preserve field order (parent before child).
+	if bag.parent != nil {
+		f.encodeBag(bag.parent)
+	}
+	for _, field := range bag.fields {
+		field.Accept(f)
 	}
 }
 

--- a/logger.go
+++ b/logger.go
@@ -99,17 +99,8 @@ func (l *Logger) WithCallerSkip(skip int) *Logger {
 
 // With returns a new Logger with the given additional fields.
 func (l *Logger) With(fs ...Field) *Logger {
-	var fields []Field
-	if l.bag == nil {
-		fields = fs
-	} else {
-		fields = make([]Field, 0, len(l.bag.Fields())+len(fs))
-		fields = append(fields, l.bag.Fields()...)
-		fields = append(fields, fs...)
-	}
-
 	cc := l.clone()
-	cc.bag = NewBag(fields...)
+	cc.bag = l.bag.With(fs...)
 
 	return cc
 }

--- a/sloghandler.go
+++ b/sloghandler.go
@@ -51,7 +51,6 @@ type slogHandler struct {
 	opts SlogHandlerOptions
 
 	// bag holds pre-resolved logf fields from WithAttrs calls.
-	// Bag.Version() serves as the cache key for the JSON encoder.
 	bag *Bag
 
 	// prefix accumulates dot-separated group names: "http.request."


### PR DESCRIPTION
Replace flat-slice Bag with linked list:
- With() creates a new node pointing to parent — O(1), no merge copy
- Fields() walks chain collecting parent-first order
- HasField() walks chain without allocation
- Remove version field and global atomic counter
- Remove LRU cache from jsonEncoder (encodeBag walks list directly)
- Simplify Logger.With() to delegate to Bag.With()

With() benchmark improvement:
  Before: 122 ns, 384 B, 3 allocs
  After:   83 ns, 320 B, 2 allocs  (-32% ns, -17% B, -1 alloc)

WithOnTop() (With on pre-attached fields):
  Before: 247 ns, 960 B, 4 allocs
  After:   86 ns, 320 B, 2 allocs  (-65% ns, -67% B, -2 allocs)

Accumulated fields logging ~30% slower without cache. Encoder slot cache will restore cached encoding in a follow-up.