### PR TITLE
field: add Group field type for nested JSON objects

### DIFF
--- a/benchmarks/light_test.go
+++ b/benchmarks/light_test.go
@@ -2,6 +2,7 @@ package benchmarks
 
 import (
 	"context"
+	"log/slog"
 	"testing"
 
 	"github.com/ssgreg/logf/v2"
@@ -112,6 +113,75 @@ func BenchmarkLightTextWithFields(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			logger.WithFields(logrusFields()).Info(getMessage(0))
+		}
+	})
+}
+
+func BenchmarkGroupField(b *testing.B) {
+	b.Run("logf", func(b *testing.B) {
+		logger, close := newLogger(logf.LevelDebug)
+		defer close()
+		logger = logger.WithCaller(false)
+		ctx := context.Background()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			logger.Info(ctx, getMessage(0),
+				logf.Group("request",
+					logf.String("method", "GET"),
+					logf.String("path", "/api/v1/users"),
+					logf.Int("status", 200),
+				),
+				logf.String("user", "alice"),
+				logf.Int64("latency_us", 1234),
+			)
+		}
+	})
+	b.Run("logf.sync", func(b *testing.B) {
+		logger := newSyncLogger(logf.LevelDebug).WithCaller(false)
+		ctx := context.Background()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			logger.Info(ctx, getMessage(0),
+				logf.Group("request",
+					logf.String("method", "GET"),
+					logf.String("path", "/api/v1/users"),
+					logf.Int("status", 200),
+				),
+				logf.String("user", "alice"),
+				logf.Int64("latency_us", 1234),
+			)
+		}
+	})
+	b.Run("uber/zap", func(b *testing.B) {
+		logger := newZapLogger(zap.DebugLevel)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			logger.Info(getMessage(0),
+				zap.Dict("request",
+					zap.String("method", "GET"),
+					zap.String("path", "/api/v1/users"),
+					zap.Int("status", 200),
+				),
+				zap.String("user", "alice"),
+				zap.Int64("latency_us", 1234),
+			)
+		}
+	})
+	b.Run("log/slog", func(b *testing.B) {
+		logger := newSlogLogger()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			logger.Info(getMessage(0),
+				slog.Group("request",
+					slog.String("method", "GET"),
+					slog.String("path", "/api/v1/users"),
+					slog.Int("status", 200),
+				),
+				slog.String("user", "alice"),
+				slog.Int64("latency_us", 1234),
+			)
 		}
 	})
 }

--- a/common_test.go
+++ b/common_test.go
@@ -342,6 +342,10 @@ func (e *testFieldEncoder) EncodeFieldObject(k string, v ObjectEncoder) {
 	e.result[k] = v
 }
 
+func (e *testFieldEncoder) EncodeFieldGroup(k string, fs []Field) {
+	e.result[k] = fs
+}
+
 type testObjectEncoder struct{}
 
 func (o testObjectEncoder) EncodeLogfObject(e FieldEncoder) error {

--- a/encoder.go
+++ b/encoder.go
@@ -123,6 +123,7 @@ type FieldEncoder interface {
 	EncodeFieldDurations(string, []time.Duration)
 	EncodeFieldArray(string, ArrayEncoder)
 	EncodeFieldObject(string, ObjectEncoder)
+	EncodeFieldGroup(string, []Field)
 }
 
 // TypeEncoderFactory defines the interface that allows to reuse Encoder

--- a/field.go
+++ b/field.go
@@ -358,6 +358,19 @@ func Object(k string, v ObjectEncoder) Field {
 	return Field{Key: k, Type: FieldTypeObject, Any: v}
 }
 
+// Group returns a new Field that encodes the given fields as a nested
+// object under the given key.
+//
+// Example:
+//
+//	logger.Info(ctx, "done",
+//	    logf.Group("request", logf.String("id", "abc"), logf.Int("status", 200)),
+//	)
+//	// → {"msg":"done", "request":{"id":"abc", "status":200}}
+func Group(k string, fs ...Field) Field {
+	return Field{Key: k, Type: FieldTypeGroup, Any: fs}
+}
+
 // ConstStringer returns a new Field with the given key and Stringer.
 // Call ConstStringer if your object is const. It has significantly less
 // impact on the calling goroutine.
@@ -544,6 +557,7 @@ const (
 
 	FieldTypeArray
 	FieldTypeObject
+	FieldTypeGroup
 	FieldTypeStringer
 	FieldTypeFormatter
 )
@@ -636,6 +650,10 @@ func (fd Field) Accept(v FieldEncoder) {
 			v.EncodeFieldObject(fd.Key, fd.Any.(ObjectEncoder))
 		} else {
 			v.EncodeFieldString(fd.Key, "nil")
+		}
+	case FieldTypeGroup:
+		if fd.Any != nil {
+			v.EncodeFieldGroup(fd.Key, fd.Any.([]Field))
 		}
 	case FieldTypeStringer:
 		if fd.Any != nil {

--- a/field_test.go
+++ b/field_test.go
@@ -859,6 +859,16 @@ func TestFieldAccept(t *testing.T) {
 			original: Any("k", customStruct{42}),
 			expected: customStruct{42},
 		},
+		{
+			name:     "Group",
+			original: Group("k", String("a", "hello"), Int("b", 42)),
+			expected: []Field{String("a", "hello"), Int("b", 42)},
+		},
+		{
+			name:     "Group/empty",
+			original: Group("k"),
+			expected: []Field(nil),
+		},
 	}
 
 	for _, c := range cases {

--- a/jsonencoder.go
+++ b/jsonencoder.go
@@ -296,6 +296,16 @@ func (f *jsonEncoder) EncodeFieldObject(k string, v ObjectEncoder) {
 	f.EncodeTypeObject(v)
 }
 
+func (f *jsonEncoder) EncodeFieldGroup(k string, fs []Field) {
+	f.addKey(k)
+	f.appendSeparator()
+	f.buf.AppendByte('{')
+	for _, field := range fs {
+		field.Accept(f)
+	}
+	f.buf.AppendByte('}')
+}
+
 func (f *jsonEncoder) EncodeFieldBytes(k string, v []byte) {
 	f.addKey(k)
 	f.EncodeTypeBytes(v)

--- a/jsonencoder_test.go
+++ b/jsonencoder_test.go
@@ -223,6 +223,33 @@ func TestEncoder(t *testing.T) {
 			`{"level":"error","ts":"0001-01-01T00:00:00Z","msg":"","any":{"Field":"42"}}` + "\n",
 		},
 		{
+			"FieldsGroup",
+			Entry{
+				Fields: []Field{
+					Group("request", String("id", "abc"), Int("status", 200)),
+				},
+			},
+			`{"level":"error","ts":"0001-01-01T00:00:00Z","msg":"","request":{"id":"abc","status":200}}` + "\n",
+		},
+		{
+			"FieldsGroupEmpty",
+			Entry{
+				Fields: []Field{
+					Group("empty"),
+				},
+			},
+			`{"level":"error","ts":"0001-01-01T00:00:00Z","msg":"","empty":{}}` + "\n",
+		},
+		{
+			"FieldsGroupNested",
+			Entry{
+				Fields: []Field{
+					Group("outer", String("a", "1"), Group("inner", Int("b", 2))),
+				},
+			},
+			`{"level":"error","ts":"0001-01-01T00:00:00Z","msg":"","outer":{"a":"1","inner":{"b":2}}}` + "\n",
+		},
+		{
 			"FieldsLoggerBag",
 			Entry{
 				LoggerBag: NewBag(


### PR DESCRIPTION
Group(key, fields...) creates a Field that encodes its sub-fields as a nested JSON object. Supports nesting (Group inside Group) and empty groups.

Changes:
- Add FieldTypeGroup to FieldType enum
- Add Group() constructor in field.go
- Add EncodeFieldGroup to FieldEncoder interface
- Implement EncodeFieldGroup in jsonEncoder
- Tests: Field.Accept, JSON encoding (simple, empty, nested)
- Benchmarks: BenchmarkGroupField (logf vs zap.Dict vs slog.Group)

Benchmark results (Apple M1 Pro):
  logf.sync  518 ns/op  376 B/op  3 allocs/op
  zap        696 ns/op  408 B/op  3 allocs/op
  slog      1109 ns/op  576 B/op  9 allocs/op