### PR TITLE
feat: Logger.WithGroup, Bag.WithGroup, simplified slogHandler

### DIFF
--- a/SLOG_INTEGRATION.md
+++ b/SLOG_INTEGRATION.md
@@ -501,34 +501,45 @@ type Bag struct {
     fields []Field
     parent *Bag
     group  string     // empty = no group
-    cache  [][]byte
+    cache  atomic.Pointer[bagCache]
 }
 ```
 
-Encoder tracks open groups, closes them after all fields:
+Encoder splits group nodes and field nodes:
+
+- **Group node** (`bag.group != ""`): writes `"name":{` directly, no caching.
+  Trivially cheap — one `addKey` + one byte.
+- **Field node**: uses per-encoder slot cache. Cached bytes include all
+  parent content (including group openings from parent group nodes).
+- **Closing braces**: `countGroups(bag)` walks the Bag chain to count
+  open groups, appends `}` after entry fields.
 
 ```go
 func (f *jsonEncoder) encodeBag(bag *Bag) {
     if bag == nil { return }
-    if bag.cache != nil {
-        if data := bag.cache[f.slot]; data != nil {
-            f.buf.AppendBytes(data.bytes)
-            f.openGroups += data.groups
-            return
-        }
-    }
-    start := f.buf.Len()
-    startGroups := f.openGroups
-    f.encodeBag(bag.parent)
+
+    // Group node: just open nested object, no caching.
     if bag.group != "" {
+        f.encodeBag(bag.parent)
         f.addKey(bag.group)
         f.buf.AppendByte('{')
-        f.openGroups++
+        return
     }
+
+    // Field node: use cache.
+    if data := bag.LoadCache(f.slot); data != nil {
+        f.buf.AppendBytes(data)
+        return
+    }
+    start := f.buf.Len()
+    f.encodeBag(bag.parent)
     for _, field := range bag.fields { field.Accept(f) }
-    // cache stores bytes + open group count
+    bag.StoreCache(f.slot, f.buf.Data[start:])
 }
 ```
+
+Cache stays a plain `[]byte` — no encoder-specific metadata (like group
+count) leaks into Bag. Group counting is O(depth), depth is typically 1-3.
 
 #### WithGroup vs WithName
 
@@ -543,20 +554,24 @@ WithName = "where am I?" (metadata). WithGroup = "nest my fields" (structure).
 
 #### slog adapter
 
+slogHandler is a thin bridge — no prefix, no clone, just Bag:
+
 ```go
 func (h *slogHandler) WithGroup(name string) slog.Handler {
-    h2 := h.clone()
-    h2.bag = &Bag{group: name, parent: h.bag,
-        cache: make([][]byte, h.slotCount)}
-    return h2
+    return &slogHandler{w: h.w, opts: h.opts, bag: h.bag.WithGroup(name)}
 }
 
 func (h *slogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
-    h2 := h.clone()
-    h2.bag = h.bag.With(h.slotCount, convertAttrs(attrs)...)
-    return h2
+    return &slogHandler{w: h.w, opts: h.opts, bag: h.bag.With(convertAttrs(attrs)...)}
 }
 ```
+
+Groups are always nested (matching slog.JSONHandler). No NestedGroups
+option — if flat keys are needed, configure the encoder.
+
+**TODO:** Add ReplaceAttr support to SlogHandlerOptions. The empty-attr
+check in `attrToField` (`a.Equal(slog.Attr{})`) exists for this —
+ReplaceAttr can return zero Attr to suppress a field.
 
 Bag linked list preserves WithGroup/WithAttrs ordering naturally.
 Multiple WithAttrs after WithGroup all land inside the group — no

--- a/bag.go
+++ b/bag.go
@@ -41,6 +41,7 @@ func AllocEncoderSlot() int {
 type Bag struct {
 	fields []Field
 	parent *Bag
+	group  string // group name; empty = no group
 	cache  atomic.Pointer[bagCache]
 }
 
@@ -54,6 +55,21 @@ func NewBag(fs ...Field) *Bag {
 // O(1): no field copy, new node points to parent.
 func (b *Bag) With(fs ...Field) *Bag {
 	return &Bag{fields: fs, parent: b}
+}
+
+// WithGroup returns a new Bag that opens a named group.
+// All fields added to descendant nodes (via With) will be logically
+// nested under this group when encoded. The original Bag is not modified.
+func (b *Bag) WithGroup(name string) *Bag {
+	return &Bag{group: name, parent: b}
+}
+
+// Group returns the group name for this Bag node, or empty string.
+func (b *Bag) Group() string {
+	if b == nil {
+		return ""
+	}
+	return b.group
 }
 
 // Fields returns all fields in the Bag chain, parent-first order.

--- a/bag_test.go
+++ b/bag_test.go
@@ -108,3 +108,29 @@ func TestBagFromContextNil(t *testing.T) {
 	got := BagFromContext(context.Background())
 	assert.Nil(t, got)
 }
+
+func TestBagWithGroup(t *testing.T) {
+	bag := NewBag(String("a", "1")).WithGroup("http").With(String("method", "GET"))
+
+	assert.Equal(t, "", bag.Group())
+	assert.Equal(t, "http", bag.Parent().Group())
+	assert.Equal(t, "", bag.Parent().Parent().Group())
+
+	// OwnFields: only the child node has fields.
+	assert.Equal(t, 1, len(bag.OwnFields()))
+	assert.Equal(t, "method", bag.OwnFields()[0].Key)
+}
+
+func TestBagWithGroupNil(t *testing.T) {
+	var bag *Bag
+	bag2 := bag.WithGroup("g")
+
+	require.NotNil(t, bag2)
+	assert.Equal(t, "g", bag2.Group())
+	assert.Nil(t, bag2.Parent())
+}
+
+func TestBagGroupNil(t *testing.T) {
+	var bag *Bag
+	assert.Equal(t, "", bag.Group())
+}

--- a/benchmarks/light_test.go
+++ b/benchmarks/light_test.go
@@ -117,6 +117,60 @@ func BenchmarkLightTextWithFields(b *testing.B) {
 	})
 }
 
+func BenchmarkWithGroup(b *testing.B) {
+	b.Run("logf", func(b *testing.B) {
+		logger, close := newLogger(logf.LevelDebug)
+		defer close()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = logger.WithGroup("http")
+		}
+	})
+	b.Run("log/slog", func(b *testing.B) {
+		logger := newSlogLogger()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = logger.WithGroup("http")
+		}
+	})
+}
+
+func BenchmarkWithGroupAccumulated(b *testing.B) {
+	b.Run("logf.sync", func(b *testing.B) {
+		logger := newSyncLogger(logf.LevelDebug).
+			WithCaller(false).
+			WithGroup("http").
+			With(logf.String("method", "GET"), logf.String("path", "/api/v1/users"))
+		ctx := context.Background()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			logger.Info(ctx, getMessage(0), logf.Int("status", 200))
+		}
+	})
+	b.Run("uber/zap", func(b *testing.B) {
+		logger := newZapLogger(zap.DebugLevel).
+			WithOptions(zap.WithCaller(false)).
+			With(zap.Namespace("http"),
+				zap.String("method", "GET"), zap.String("path", "/api/v1/users"))
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			logger.Info(getMessage(0), zap.Int("status", 200))
+		}
+	})
+	b.Run("log/slog", func(b *testing.B) {
+		logger := newSlogLogger().WithGroup("http").With("method", "GET", "path", "/api/v1/users")
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			logger.Info(getMessage(0), "status", 200)
+		}
+	})
+}
+
 func BenchmarkGroupField(b *testing.B) {
 	b.Run("logf", func(b *testing.B) {
 		logger, close := newLogger(logf.LevelDebug)

--- a/benchmarks/logf_test.go
+++ b/benchmarks/logf_test.go
@@ -98,6 +98,31 @@ func BenchmarkLogfLoggerWithOnTop(b *testing.B) {
 	}
 }
 
+// --- Logger.WithGroup ---
+
+func BenchmarkLogfLoggerWithGroup(b *testing.B) {
+	logger, close := newLogger(logf.LevelDebug)
+	defer close()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = logger.WithGroup("http")
+	}
+}
+
+func BenchmarkLogfSyncTextWithGroupAndFields(b *testing.B) {
+	logger := newSyncLogger(logf.LevelDebug).
+		WithCaller(false).
+		WithGroup("http").
+		With(logfFields()...)
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.Info(ctx, getMessage(0), logf.Int("status", 200))
+	}
+}
+
 // --- Accumulated fields (pre-attached via With) ---
 
 func BenchmarkLogfTextWithAccumulatedFields(b *testing.B) {

--- a/field.go
+++ b/field.go
@@ -512,6 +512,9 @@ func Any(k string, v interface{}) Field {
 		if s, ok := rv.(Snapshotter); ok {
 			return Field{Key: k, Type: FieldTypeAny, Any: s.TakeSnapshot()}
 		}
+		if s, ok := rv.(fmt.Stringer); ok {
+			return String(k, s.String())
+		}
 	}
 
 	return Field{Key: k, Type: FieldTypeAny, Any: v}

--- a/field_test.go
+++ b/field_test.go
@@ -2,6 +2,7 @@ package logf
 
 import (
 	"errors"
+	"net"
 	"testing"
 	"time"
 
@@ -443,6 +444,13 @@ func TestFieldNilError(t *testing.T) {
 	e := newTestFieldEncoder()
 	f.Accept(e)
 	assert.Equal(t, nil, e.result["error"])
+}
+
+func TestFieldAnyStringer(t *testing.T) {
+	f := Any("k", net.IPv4(192, 168, 1, 1))
+	e := newTestFieldEncoder()
+	f.Accept(e)
+	assert.Equal(t, "192.168.1.1", e.result["k"])
 }
 
 func TestFieldAnyWithCustomType(t *testing.T) {

--- a/jsonencoder.go
+++ b/jsonencoder.go
@@ -165,10 +165,26 @@ func (f *jsonEncoder) Encode(buf *Buffer, e Entry) error {
 		field.Accept(f)
 	}
 
+	// Close open groups (from WithGroup in Bag chains).
+	for n := countGroups(e.Bag) + countGroups(e.LoggerBag); n > 0; n-- {
+		buf.AppendByte('}')
+	}
+
 	buf.AppendByte('}')
 	buf.AppendByte('\n')
 
 	return nil
+}
+
+// countGroups counts group nodes in a Bag chain.
+func countGroups(bag *Bag) int {
+	n := 0
+	for b := bag; b != nil; b = b.parent {
+		if b.group != "" {
+			n++
+		}
+	}
+	return n
 }
 
 func (f *jsonEncoder) encodeBag(bag *Bag) {
@@ -176,7 +192,15 @@ func (f *jsonEncoder) encodeBag(bag *Bag) {
 		return
 	}
 
-	// Cache hit: encoded bytes for this node + all parents.
+	// Group node: just open a nested JSON object, no caching needed.
+	if bag.group != "" {
+		f.encodeBag(bag.parent)
+		f.addKey(bag.group)
+		f.buf.AppendByte('{')
+		return
+	}
+
+	// Field node: use cache.
 	if data := bag.LoadCache(f.slot); data != nil {
 		f.buf.AppendBytes(data)
 		return
@@ -185,14 +209,13 @@ func (f *jsonEncoder) encodeBag(bag *Bag) {
 	start := f.buf.Len()
 
 	// Walk parent first to preserve field order (parent before child).
-	if bag.parent != nil {
-		f.encodeBag(bag.parent)
-	}
+	f.encodeBag(bag.parent)
+
 	for _, field := range bag.fields {
 		field.Accept(f)
 	}
 
-	// Cache the encoded bytes (this node + all parents).
+	// Cache the encoded bytes (includes parent content).
 	if f.slot != 0 {
 		encoded := make([]byte, f.buf.Len()-start)
 		copy(encoded, f.buf.Data[start:])

--- a/jsonencoder_test.go
+++ b/jsonencoder_test.go
@@ -270,6 +270,38 @@ func TestEncoder(t *testing.T) {
 			},
 			`{"level":"error","ts":"0001-01-01T00:00:00Z","msg":"","int":42,"string":"42"}` + "\n",
 		},
+		{
+			"WithGroup",
+			Entry{
+				LoggerBag: NewBag(String("a", "1")).WithGroup("http").With(String("method", "GET")),
+				Fields:    []Field{Int("status", 200)},
+			},
+			`{"level":"error","ts":"0001-01-01T00:00:00Z","msg":"","a":"1","http":{"method":"GET","status":200}}` + "\n",
+		},
+		{
+			"WithGroupNested",
+			Entry{
+				LoggerBag: NewBag().WithGroup("http").WithGroup("request").With(String("path", "/api")),
+				Fields:    []Field{Int("status", 200)},
+			},
+			`{"level":"error","ts":"0001-01-01T00:00:00Z","msg":"","http":{"request":{"path":"/api","status":200}}}` + "\n",
+		},
+		{
+			"WithGroupNoFields",
+			Entry{
+				LoggerBag: NewBag().WithGroup("http"),
+				Fields:    []Field{Int("status", 200)},
+			},
+			`{"level":"error","ts":"0001-01-01T00:00:00Z","msg":"","http":{"status":200}}` + "\n",
+		},
+		{
+			"WithGroupAndWith",
+			Entry{
+				LoggerBag: NewBag().WithGroup("http").With(String("method", "GET")).With(String("path", "/api")),
+				Fields:    []Field{Int("status", 200)},
+			},
+			`{"level":"error","ts":"0001-01-01T00:00:00Z","msg":"","http":{"method":"GET","path":"/api","status":200}}` + "\n",
+		},
 	}
 
 	enc := NewJSONEncoder.Default()

--- a/logger.go
+++ b/logger.go
@@ -105,6 +105,21 @@ func (l *Logger) With(fs ...Field) *Logger {
 	return cc
 }
 
+// WithGroup returns a new Logger that nests all subsequent fields
+// (from With and per-call) under the given group name.
+// Produces nested JSON objects: WithGroup("http") + Int("status", 200)
+// → {"http":{"status":200}}.
+func (l *Logger) WithGroup(name string) *Logger {
+	if name == "" {
+		return l
+	}
+
+	cc := l.clone()
+	cc.bag = l.bag.WithGroup(name)
+
+	return cc
+}
+
 // Debug logs a debug message with the given text, optional fields and
 // fields passed to the Logger using With function.
 func (l *Logger) Debug(ctx context.Context, text string, fs ...Field) {

--- a/logger_test.go
+++ b/logger_test.go
@@ -260,6 +260,46 @@ func TestUnbufferedWriter(t *testing.T) {
 	assert.Equal(t, LevelError, a.Entries[4].Level)
 }
 
+func TestLoggerWithGroup(t *testing.T) {
+	w := &testEntryWriter{}
+	logger := NewLogger(w).WithGroup("http")
+
+	logger.Error(ctx, "done", Int("status", 200))
+	require.NotNil(t, w.Entry.LoggerBag)
+	assert.Equal(t, "http", w.Entry.LoggerBag.Group())
+}
+
+func TestLoggerWithGroupEmpty(t *testing.T) {
+	w := &testEntryWriter{}
+	logger := NewLogger(w)
+	same := logger.WithGroup("")
+
+	// Empty group name returns the same logger.
+	assert.Equal(t, logger, same)
+}
+
+func TestLoggerWithGroupChain(t *testing.T) {
+	w := &testEntryWriter{}
+	logger := NewLogger(w).
+		With(String("service", "api")).
+		WithGroup("http").
+		With(String("method", "GET"))
+
+	logger.Error(ctx, "done")
+	bag := w.Entry.LoggerBag
+
+	// Child node has method field.
+	assert.Equal(t, 1, len(bag.OwnFields()))
+	assert.Equal(t, "method", bag.OwnFields()[0].Key)
+
+	// Parent is group node.
+	assert.Equal(t, "http", bag.Parent().Group())
+
+	// Grandparent has service field.
+	assert.Equal(t, 1, len(bag.Parent().Parent().OwnFields()))
+	assert.Equal(t, "service", bag.Parent().Parent().OwnFields()[0].Key)
+}
+
 func TestContext(t *testing.T) {
 	// Check if no logger is associated with the Context — returns DisabledLogger.
 	assert.Equal(t, DisabledLogger(), FromContext(context.Background()))

--- a/sloghandler.go
+++ b/sloghandler.go
@@ -2,7 +2,6 @@ package logf
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 )
 
@@ -11,19 +10,6 @@ type SlogHandlerOptions struct {
 	// Level is the minimum enabled severity.
 	// If nil, defaults to slog.LevelInfo.
 	Level slog.Leveler
-
-	// NestedGroups controls how slog.WithGroup maps to logf fields.
-	//
-	// When false (default), groups produce dot-prefixed flat keys
-	// matching slog.TextHandler behavior:
-	//
-	//   WithGroup("http") + "method" → "http.method"
-	//
-	// When true, groups produce nested JSON objects
-	// via logf.Object / ObjectEncoder:
-	//
-	//   WithGroup("http") + "method" → {"http":{"method":"GET"}}
-	NestedGroups bool
 }
 
 // NewSlogHandler returns a [slog.Handler] that writes log records
@@ -50,16 +36,9 @@ type slogHandler struct {
 	w    EntryWriter
 	opts SlogHandlerOptions
 
-	// bag holds pre-resolved logf fields from WithAttrs calls.
+	// bag holds pre-resolved logf fields from WithAttrs calls
+	// and group nodes from WithGroup calls (via Bag.WithGroup).
 	bag *Bag
-
-	// prefix accumulates dot-separated group names: "http.request."
-	// Used only when NestedGroups is false.
-	prefix string
-
-	// groups accumulates group names: ["http", "request"]
-	// Used only when NestedGroups is true.
-	groups []string
 }
 
 // Enabled reports whether the handler is enabled for the given level.
@@ -80,20 +59,10 @@ func (h *slogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 		return h
 	}
 
-	converted := h.convertAttrs(attrs)
-	var bag *Bag
-	if h.bag != nil {
-		bag = h.bag.With(converted...)
-	} else {
-		bag = NewBag(converted...)
-	}
-
 	return &slogHandler{
-		w:      h.w,
-		opts:   h.opts,
-		bag:    bag,
-		prefix: h.prefix,
-		groups: h.groups,
+		w:    h.w,
+		opts: h.opts,
+		bag:  h.bag.With(convertAttrs(attrs)...),
 	}
 }
 
@@ -104,48 +73,22 @@ func (h *slogHandler) WithGroup(name string) slog.Handler {
 		return h
 	}
 
-	nh := &slogHandler{
+	return &slogHandler{
 		w:    h.w,
 		opts: h.opts,
-		bag:  h.bag,
+		bag:  h.bag.WithGroup(name),
 	}
-
-	if h.opts.NestedGroups {
-		nh.groups = appendString(h.groups, name)
-	} else {
-		nh.prefix = h.prefix + name + "."
-	}
-
-	return nh
 }
 
 // buildEntry assembles a logf.Entry from a slog.Record.
 func (h *slogHandler) buildEntry(r slog.Record) Entry {
-	e := h.buildFields(r)
-	e.Level = slogLevelToLogf(r.Level)
-	e.Text = r.Message
-	e.Time = r.Time
-	e.CallerPC = r.PC
-
-	return e
-}
-
-// buildFields populates LoggerBag and Fields of the entry.
-//
-// Dot-prefix mode: bag attrs go to LoggerBag, record attrs go to Fields.
-// Nested mode:     all fields are merged, wrapped in Objects, put into Fields.
-func (h *slogHandler) buildFields(r slog.Record) Entry {
-	recordFields := h.collectRecordFields(r)
-
-	if h.opts.NestedGroups && len(h.groups) > 0 {
-		all := cloneAppend(h.bag.Fields(), recordFields)
-
-		return Entry{Fields: wrapGroups(h.groups, all)}
-	}
-
 	return Entry{
 		LoggerBag: h.bag,
-		Fields:    recordFields,
+		Fields:    h.collectRecordFields(r),
+		Level:     slogLevelToLogf(r.Level),
+		Text:      r.Message,
+		Time:      r.Time,
+		CallerPC:  r.PC,
 	}
 }
 
@@ -157,30 +100,12 @@ func (h *slogHandler) collectRecordFields(r slog.Record) []Field {
 
 	fields := make([]Field, 0, r.NumAttrs())
 	r.Attrs(func(a slog.Attr) bool {
-		if f := attrToField(h.prefix, a); f.Key != "" {
+		if f := attrToField(a); f.Key != "" {
 			fields = append(fields, f)
 		}
 
 		return true
 	})
-
-	return fields
-}
-
-// convertAttrs converts slog attributes to logf fields,
-// applying the current prefix in dot-prefix mode.
-func (h *slogHandler) convertAttrs(attrs []slog.Attr) []Field {
-	prefix := h.prefix
-	if h.opts.NestedGroups {
-		prefix = ""
-	}
-
-	fields := make([]Field, 0, len(attrs))
-	for _, a := range attrs {
-		if f := attrToField(prefix, a); f.Key != "" {
-			fields = append(fields, f)
-		}
-	}
 
 	return fields
 }
@@ -211,116 +136,53 @@ func slogLevelToLogf(l slog.Level) Level {
 }
 
 // attrToField converts a single slog.Attr to a logf.Field.
-//
-// Conversion rules:
-//   - KindBool/Int64/Uint64/Float64/String/Time/Duration → typed Field
-//   - KindGroup with children → logf.Object (fieldsObject)
-//   - KindGroup empty         → skipped (zero Field)
-//   - error value             → logf.NamedError
-//   - fmt.Stringer value      → logf.String (eagerly resolved)
-//   - anything else           → logf.Any
-//
-// LogValuer values are resolved before conversion via slog.Value.Resolve.
-func attrToField(prefix string, a slog.Attr) Field {
+func attrToField(a slog.Attr) Field {
 	a.Value = a.Value.Resolve()
 
 	if a.Equal(slog.Attr{}) {
 		return Field{}
 	}
 
-	key := prefix + a.Key
-
 	switch a.Value.Kind() {
 	case slog.KindBool:
-		return Bool(key, a.Value.Bool())
+		return Bool(a.Key, a.Value.Bool())
 	case slog.KindInt64:
-		return Int64(key, a.Value.Int64())
+		return Int64(a.Key, a.Value.Int64())
 	case slog.KindUint64:
-		return Uint64(key, a.Value.Uint64())
+		return Uint64(a.Key, a.Value.Uint64())
 	case slog.KindFloat64:
-		return Float64(key, a.Value.Float64())
+		return Float64(a.Key, a.Value.Float64())
 	case slog.KindString:
-		return String(key, a.Value.String())
+		return String(a.Key, a.Value.String())
 	case slog.KindTime:
-		return Time(key, a.Value.Time())
+		return Time(a.Key, a.Value.Time())
 	case slog.KindDuration:
-		return Duration(key, a.Value.Duration())
+		return Duration(a.Key, a.Value.Duration())
 	case slog.KindGroup:
-		return groupAttrToField(key, a.Value.Group())
+		return groupAttrToField(a.Key, a.Value.Group())
 	default:
-		return anyToField(key, a.Value.Any())
+		return Any(a.Key, a.Value.Any())
 	}
 }
 
-// groupAttrToField converts a slog group attribute to a logf.Object field.
+// groupAttrToField converts a slog group attribute to a logf.Group field.
 // Returns a zero Field if the group is empty.
 func groupAttrToField(key string, attrs []slog.Attr) Field {
 	if len(attrs) == 0 {
 		return Field{}
 	}
 
-	inner := make(fieldsObject, 0, len(attrs))
-	for _, ga := range attrs {
-		if f := attrToField("", ga); f.Key != "" {
-			inner = append(inner, f)
+	return Group(key, convertAttrs(attrs)...)
+}
+
+// convertAttrs converts slog attributes to logf fields.
+func convertAttrs(attrs []slog.Attr) []Field {
+	fields := make([]Field, 0, len(attrs))
+	for _, a := range attrs {
+		if f := attrToField(a); f.Key != "" {
+			fields = append(fields, f)
 		}
 	}
 
-	return Object(key, inner)
-}
-
-// anyToField handles slog.KindAny with special cases for error
-// and fmt.Stringer interfaces.
-func anyToField(key string, v any) Field {
-	if err, ok := v.(error); ok {
-		return NamedError(key, err)
-	}
-	if s, ok := v.(fmt.Stringer); ok {
-		return String(key, s.String())
-	}
-
-	return Any(key, v)
-}
-
-// wrapGroups folds fields into nested logf.Object fields, right-to-left:
-//
-//	["http", "request"] + [method=GET]
-//	→ [Object("http", Object("request", method=GET))]
-func wrapGroups(groups []string, fields []Field) []Field {
-	for i := len(groups) - 1; i >= 0; i-- {
-		fields = []Field{Object(groups[i], fieldsObject(fields))}
-	}
-
 	return fields
-}
-
-// fieldsObject adapts a []Field slice to the ObjectEncoder interface,
-// allowing it to be used as the value of a logf.Object field.
-type fieldsObject []Field
-
-func (fo fieldsObject) EncodeLogfObject(enc FieldEncoder) error {
-	for _, f := range fo {
-		f.Accept(enc)
-	}
-
-	return nil
-}
-
-// cloneAppend creates a new slice containing all elements of base
-// followed by all elements of extra. The base slice is never mutated.
-func cloneAppend(base, extra []Field) []Field {
-	result := make([]Field, len(base), len(base)+len(extra))
-	copy(result, base)
-
-	return append(result, extra...)
-}
-
-// appendString returns a new slice with s appended.
-// The original slice is never mutated.
-func appendString(ss []string, s string) []string {
-	result := make([]string, len(ss)+1)
-	copy(result, ss)
-	result[len(ss)] = s
-
-	return result
 }

--- a/sloghandler_test.go
+++ b/sloghandler_test.go
@@ -107,44 +107,40 @@ func TestSlogHandlerJSON(t *testing.T) {
 			`{"level":"info","msg":"login","component":"auth","user":"alice"}`,
 		},
 		{
-			"group/dot-prefix",
+			"group",
 			nil,
 			func(l *slog.Logger) { l.WithGroup("http").Info("req", "method", "GET", "path", "/api") },
-			`{"level":"info","msg":"req","http.method":"GET","http.path":"/api"}`,
+			`{"level":"info","msg":"req","http":{"method":"GET","path":"/api"}}`,
 		},
 		{
-			"group/dot-prefix-multiple",
+			"group-multiple",
 			nil,
-			func(l *slog.Logger) { l.WithGroup("http").WithGroup("request").Info("got", "method", "GET") },
-			`{"level":"info","msg":"got","http.request.method":"GET"}`,
-		},
-		{
-			"group/nested",
-			&SlogHandlerOptions{NestedGroups: true},
-			func(l *slog.Logger) { l.WithGroup("http").Info("req", "method", "GET") },
-			`{"level":"info","msg":"req","http":{"method":"GET"}}`,
-		},
-		{
-			"group/nested-multiple",
-			&SlogHandlerOptions{NestedGroups: true},
 			func(l *slog.Logger) { l.WithGroup("http").WithGroup("request").Info("got", "method", "GET") },
 			`{"level":"info","msg":"got","http":{"request":{"method":"GET"}}}`,
 		},
 		{
-			"group/dot-prefix+attrs",
+			"group+attrs",
 			nil,
-			func(l *slog.Logger) {
-				l.With("app", "myapp").WithGroup("http").With("host", "localhost").Info("req", "method", "GET")
-			},
-			`{"level":"info","msg":"req","app":"myapp","http.host":"localhost","http.method":"GET"}`,
-		},
-		{
-			"group/nested+attrs",
-			&SlogHandlerOptions{NestedGroups: true},
 			func(l *slog.Logger) {
 				l.WithGroup("http").With("host", "localhost").Info("req", "method", "GET")
 			},
 			`{"level":"info","msg":"req","http":{"host":"localhost","method":"GET"}}`,
+		},
+		{
+			"group+attrs-before-group",
+			nil,
+			func(l *slog.Logger) {
+				l.With("app", "myapp").WithGroup("http").Info("req", "method", "GET")
+			},
+			`{"level":"info","msg":"req","app":"myapp","http":{"method":"GET"}}`,
+		},
+		{
+			"group-deep",
+			nil,
+			func(l *slog.Logger) {
+				l.WithGroup("http").With("host", "localhost").WithGroup("request").Info("got", "path", "/api")
+			},
+			`{"level":"info","msg":"got","http":{"host":"localhost","request":{"path":"/api"}}}`,
 		},
 		{
 			"types",


### PR DESCRIPTION
- Bag.WithGroup(name) adds a group node to the linked list
- Logger.WithGroup(name) creates a child logger with group namespace
- jsonEncoder: group nodes skip cache, field nodes cache plain []byte
- countGroups walks Bag chain to close nested JSON objects
- slogHandler: removed NestedGroups option, always nested groups
- slogHandler: removed prefix/dot-prefix mode, simplified WithAttrs
- slogHandler: use logf.Group for slog KindGroup attrs (removed fieldsObject)
- field.Any: added fmt.Stringer support (eagerly resolved to String)
- Updated SLOG_INTEGRATION.md with current design and ReplaceAttr TODO
- Benchmarks: WithGroup creation and logging with groups