### PR TITLE
slog bridge: Logger.Slog(), logfc.WithGroup, benchmarks, cleanup

### DIFF
--- a/SLOG_INTEGRATION.md
+++ b/SLOG_INTEGRATION.md
@@ -554,24 +554,30 @@ WithName = "where am I?" (metadata). WithGroup = "nest my fields" (structure).
 
 #### slog adapter
 
-slogHandler is a thin bridge — no prefix, no clone, just Bag:
+slogHandler is a thin bridge — just writer + Bag, no options:
 
 ```go
+func NewSlogHandler(w EntryWriter) slog.Handler
+
 func (h *slogHandler) WithGroup(name string) slog.Handler {
-    return &slogHandler{w: h.w, opts: h.opts, bag: h.bag.WithGroup(name)}
+    return &slogHandler{w: h.w, bag: h.bag.WithGroup(name)}
 }
 
 func (h *slogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
-    return &slogHandler{w: h.w, opts: h.opts, bag: h.bag.With(convertAttrs(attrs)...)}
+    return &slogHandler{w: h.w, bag: h.bag.With(convertAttrs(attrs)...)}
+}
+
+func (h *slogHandler) Enabled(ctx context.Context, level slog.Level) bool {
+    return h.w.Enabled(ctx, slogLevelToLogf(level))
 }
 ```
 
-Groups are always nested (matching slog.JSONHandler). No NestedGroups
-option — if flat keys are needed, configure the encoder.
+Level filtering delegated to EntryWriter (same as Logger). Groups are
+always nested (matching slog.JSONHandler).
 
-**TODO:** Add ReplaceAttr support to SlogHandlerOptions. The empty-attr
-check in `attrToField` (`a.Equal(slog.Attr{})`) exists for this —
-ReplaceAttr can return zero Attr to suppress a field.
+**TODO:** Add ReplaceAttr support. The empty-attr check in `attrToField`
+(`a.Equal(slog.Attr{})`) exists for this — ReplaceAttr can return zero
+Attr to suppress a field. Will require reintroducing an options struct.
 
 Bag linked list preserves WithGroup/WithAttrs ordering naturally.
 Multiple WithAttrs after WithGroup all land inside the group — no

--- a/benchmarks/bench_test.go
+++ b/benchmarks/bench_test.go
@@ -79,7 +79,7 @@ func BenchmarkDisabledPlainText(b *testing.B) {
 
 func BenchmarkDisabledPlainTextWithAccumulatedFields(b *testing.B) {
 	b.Run("logf", func(b *testing.B) {
-		logger := logf.NewDisabledLogger().With(fakeFields()...)
+		logger := logf.DisabledLogger().With(fakeFields()...)
 		ctx := context.Background()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -87,7 +87,7 @@ func BenchmarkDisabledPlainTextWithAccumulatedFields(b *testing.B) {
 		}
 	})
 	b.Run("logf.check", func(b *testing.B) {
-		logger := logf.NewDisabledLogger().With(fakeFields()...)
+		logger := logf.DisabledLogger().With(fakeFields()...)
 		ctx := context.Background()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -143,7 +143,7 @@ func BenchmarkDisabledPlainTextWithAccumulatedFields(b *testing.B) {
 
 func BenchmarkDisabledTextWithFields(b *testing.B) {
 	b.Run("logf", func(b *testing.B) {
-		logger := logf.NewDisabledLogger()
+		logger := logf.DisabledLogger()
 		ctx := context.Background()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -151,7 +151,7 @@ func BenchmarkDisabledTextWithFields(b *testing.B) {
 		}
 	})
 	b.Run("logf.check", func(b *testing.B) {
-		logger := logf.NewDisabledLogger()
+		logger := logf.DisabledLogger()
 		ctx := context.Background()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/benchmarks/logf_test.go
+++ b/benchmarks/logf_test.go
@@ -56,7 +56,7 @@ var benchCtx = context.Background()
 // --- Disabled path ---
 
 func BenchmarkLogfDisabledLog(b *testing.B) {
-	logger := logf.NewDisabledLogger()
+	logger := logf.DisabledLogger()
 	ctx := context.Background()
 
 	b.ResetTimer()
@@ -66,7 +66,7 @@ func BenchmarkLogfDisabledLog(b *testing.B) {
 }
 
 func BenchmarkLogfDisabledLogWithFields(b *testing.B) {
-	logger := logf.NewDisabledLogger()
+	logger := logf.DisabledLogger()
 	ctx := context.Background()
 
 	b.ResetTimer()
@@ -107,6 +107,26 @@ func BenchmarkLogfLoggerWithGroup(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = logger.WithGroup("http")
+	}
+}
+
+func BenchmarkLogfSyncPlainText(b *testing.B) {
+	logger := newSyncLogger(logf.LevelDebug).WithCaller(false)
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.Info(ctx, getMessage(0))
+	}
+}
+
+func BenchmarkLogfSyncTextWithFields(b *testing.B) {
+	logger := newSyncLogger(logf.LevelDebug).WithCaller(false)
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.Info(ctx, getMessage(0), logfFields()...)
 	}
 }
 

--- a/benchmarks/logfc_test.go
+++ b/benchmarks/logfc_test.go
@@ -1,0 +1,234 @@
+package benchmarks
+
+import (
+	"context"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/ssgreg/logf/v2"
+	"github.com/ssgreg/logf/v2/logfc"
+)
+
+// --- Disabled path ---
+
+func BenchmarkLogfcDisabledLog(b *testing.B) {
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logfc.Info(ctx, "request handled")
+	}
+}
+
+func BenchmarkLogfcDisabledLogWithFields(b *testing.B) {
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logfc.Info(ctx, "request handled", logfFields()...)
+	}
+}
+
+// --- logf vs logfc: direct comparison ---
+
+func BenchmarkLogfInfoInLoop(b *testing.B) {
+	w := logf.NewSyncWriter(logf.LevelDebug, logf.NewWriteAppender(io.Discard, logf.NewJSONEncoder.Default()))
+	logger := logf.NewLogger(w).WithCaller(false)
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.Info(ctx, "request handled")
+	}
+}
+
+func BenchmarkLogfcInfoInLoop(b *testing.B) {
+	w := logf.NewSyncWriter(logf.LevelDebug, logf.NewWriteAppender(io.Discard, logf.NewJSONEncoder.Default()))
+	ctx := logfc.New(context.Background(), logf.NewLogger(w).WithCaller(false))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logfc.Info(ctx, "request handled")
+	}
+}
+
+func BenchmarkLogfWithInLoop(b *testing.B) {
+	w := logf.NewSyncWriter(logf.LevelDebug, logf.NewWriteAppender(io.Discard, logf.NewJSONEncoder.Default()))
+	logger := logf.NewLogger(w).WithCaller(false)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = logger.With(logfFields()...)
+	}
+}
+
+func BenchmarkLogfcWithInLoop(b *testing.B) {
+	w := logf.NewSyncWriter(logf.LevelDebug, logf.NewWriteAppender(io.Discard, logf.NewJSONEncoder.Default()))
+	ctx := logfc.New(context.Background(), logf.NewLogger(w).WithCaller(false))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = logfc.With(ctx, logfFields()...)
+	}
+}
+
+// --- Context creation (per-request overhead) ---
+
+func BenchmarkLogfcContextWith(b *testing.B) {
+	w := logf.NewSyncWriter(logf.LevelDebug, logf.NewWriteAppender(io.Discard, logf.NewJSONEncoder.Default()))
+	ctx := logfc.New(context.Background(), logf.NewLogger(w).WithCaller(false))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = logfc.With(ctx, logfFields()...)
+	}
+}
+
+func BenchmarkLogfcContextWithGroup(b *testing.B) {
+	w := logf.NewSyncWriter(logf.LevelDebug, logf.NewWriteAppender(io.Discard, logf.NewJSONEncoder.Default()))
+	ctx := logfc.New(context.Background(), logf.NewLogger(w).WithCaller(false))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = logfc.WithGroup(ctx, "request")
+	}
+}
+
+func BenchmarkLogfcContextWithAndLog(b *testing.B) {
+	w := logf.NewSyncWriter(logf.LevelDebug, logf.NewWriteAppender(io.Discard, logf.NewJSONEncoder.Default()))
+	baseCtx := logfc.New(context.Background(), logf.NewLogger(w).WithCaller(false))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ctx := logfc.With(baseCtx, logfFields()...)
+		logfc.Info(ctx, "request handled")
+	}
+}
+
+// --- Sync plain text ---
+
+func BenchmarkLogfcSyncPlainText(b *testing.B) {
+	w := logf.NewSyncWriter(logf.LevelDebug, logf.NewWriteAppender(io.Discard, logf.NewJSONEncoder.Default()))
+	ctx := logfc.New(context.Background(), logf.NewLogger(w).WithCaller(false))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logfc.Info(ctx, getMessage(0))
+	}
+}
+
+func BenchmarkLogfcSyncTextWithFields(b *testing.B) {
+	w := logf.NewSyncWriter(logf.LevelDebug, logf.NewWriteAppender(io.Discard, logf.NewJSONEncoder.Default()))
+	ctx := logfc.New(context.Background(), logf.NewLogger(w).WithCaller(false))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logfc.Info(ctx, getMessage(0), logfFields()...)
+	}
+}
+
+func BenchmarkLogfcSyncTextWithAccumulatedFields(b *testing.B) {
+	w := logf.NewSyncWriter(logf.LevelDebug, logf.NewWriteAppender(io.Discard, logf.NewJSONEncoder.Default()))
+	ctx := logfc.New(context.Background(), logf.NewLogger(w).WithCaller(false))
+	ctx = logfc.With(ctx, logfFields()...)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logfc.Info(ctx, getMessage(0))
+	}
+}
+
+func BenchmarkLogfcSyncTextWithGroupAndFields(b *testing.B) {
+	w := logf.NewSyncWriter(logf.LevelDebug, logf.NewWriteAppender(io.Discard, logf.NewJSONEncoder.Default()))
+	ctx := logfc.New(context.Background(), logf.NewLogger(w).WithCaller(false))
+	ctx = logfc.WithGroup(ctx, "http")
+	ctx = logfc.With(ctx, logfFields()...)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logfc.Info(ctx, getMessage(0), logf.Int("status", 200))
+	}
+}
+
+// --- File I/O (async via ChannelWriter) ---
+
+func BenchmarkLogfcBufferedFileIO(b *testing.B) {
+	f, err := os.CreateTemp("", "logfc-bench-*.log")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	defer f.Close()
+
+	w, close := logf.NewChannelWriter(logf.LevelDebug, logf.ChannelWriterConfig{
+		Appender: logf.NewWriteAppender(f, logf.NewJSONEncoder.Default()),
+	})
+	defer close()
+	ctx := logfc.New(context.Background(), logf.NewLogger(w).WithCaller(false))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logfc.Info(ctx, "request handled")
+	}
+}
+
+func BenchmarkLogfcBufferedParallelFileIO(b *testing.B) {
+	f, err := os.CreateTemp("", "logfc-bench-*.log")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	defer f.Close()
+
+	w, close := logf.NewChannelWriter(logf.LevelDebug, logf.ChannelWriterConfig{
+		Appender: logf.NewWriteAppender(f, logf.NewJSONEncoder.Default()),
+	})
+	defer close()
+	ctx := logfc.New(context.Background(), logf.NewLogger(w).WithCaller(false))
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logfc.Info(ctx, "request handled")
+		}
+	})
+}
+
+// --- File I/O (sync via SyncWriter) ---
+
+func BenchmarkLogfcFileIO(b *testing.B) {
+	f, err := os.CreateTemp("", "logfc-bench-*.log")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	defer f.Close()
+
+	w := logf.NewSyncWriter(logf.LevelDebug, logf.NewWriteAppender(f, logf.NewJSONEncoder.Default()))
+	ctx := logfc.New(context.Background(), logf.NewLogger(w).WithCaller(false))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logfc.Info(ctx, "request handled")
+	}
+}
+
+func BenchmarkLogfcParallelFileIO(b *testing.B) {
+	f, err := os.CreateTemp("", "logfc-bench-*.log")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	defer f.Close()
+
+	w := logf.NewSyncWriter(logf.LevelDebug, logf.NewWriteAppender(f, logf.NewJSONEncoder.Default()))
+	ctx := logfc.New(context.Background(), logf.NewLogger(w).WithCaller(false))
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logfc.Info(ctx, "request handled")
+		}
+	})
+}

--- a/benchmarks/slog_test.go
+++ b/benchmarks/slog_test.go
@@ -91,6 +91,15 @@ func BenchmarkSlogTextWithFields(b *testing.B) {
 	}
 }
 
+func BenchmarkSlogTextWithGroupAndFields(b *testing.B) {
+	logger := newSlogLogger().WithGroup("http").With(slogFields()...)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.Info("request handled", "status", 200)
+	}
+}
+
 func BenchmarkSlogTextWithAccumulatedFields(b *testing.B) {
 	logger := newSlogLogger().With(slogFields()...)
 
@@ -166,7 +175,7 @@ func BenchmarkSlogViaLogfDiscard(b *testing.B) {
 		Appender: logf.NewWriteAppender(io.Discard, logf.NewJSONEncoder.Default()),
 	})
 	defer close()
-	logger := slog.New(logf.NewSlogHandler(w, nil))
+	logger := slog.New(logf.NewSlogHandler(w))
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -186,7 +195,7 @@ func BenchmarkSlogViaLogfFileIO(b *testing.B) {
 		Appender: logf.NewWriteAppender(f, logf.NewJSONEncoder.Default()),
 	})
 	defer close()
-	logger := slog.New(logf.NewSlogHandler(w, nil))
+	logger := slog.New(logf.NewSlogHandler(w))
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -206,7 +215,181 @@ func BenchmarkSlogViaLogfParallelFileIO(b *testing.B) {
 		Appender: logf.NewWriteAppender(f, logf.NewJSONEncoder.Default()),
 	})
 	defer close()
-	logger := slog.New(logf.NewSlogHandler(w, nil))
+	logger := slog.New(logf.NewSlogHandler(w))
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.Info("request handled")
+		}
+	})
+}
+
+// --- Logger.Slog() bridge ---
+
+func BenchmarkLogfSlogDiscard(b *testing.B) {
+	w, close := logf.NewChannelWriter(logf.LevelDebug, logf.ChannelWriterConfig{
+		Appender: logf.NewWriteAppender(io.Discard, logf.NewJSONEncoder.Default()),
+	})
+	defer close()
+	logger := logf.NewLogger(w).WithCaller(false).Slog()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.Info("request handled")
+	}
+}
+
+func BenchmarkLogfSlogTextWithFields(b *testing.B) {
+	w, close := logf.NewChannelWriter(logf.LevelDebug, logf.ChannelWriterConfig{
+		Appender: logf.NewWriteAppender(io.Discard, logf.NewJSONEncoder.Default()),
+	})
+	defer close()
+	logger := logf.NewLogger(w).WithCaller(false).Slog()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.Info("request handled", slogFields()...)
+	}
+}
+
+func BenchmarkLogfSlogTextWithAccumulatedFields(b *testing.B) {
+	w, close := logf.NewChannelWriter(logf.LevelDebug, logf.ChannelWriterConfig{
+		Appender: logf.NewWriteAppender(io.Discard, logf.NewJSONEncoder.Default()),
+	})
+	defer close()
+	logger := logf.NewLogger(w).WithCaller(false).Slog().With(slogFields()...)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.Info("request handled")
+	}
+}
+
+func BenchmarkLogfSlogTextWithGroupAndFields(b *testing.B) {
+	w, close := logf.NewChannelWriter(logf.LevelDebug, logf.ChannelWriterConfig{
+		Appender: logf.NewWriteAppender(io.Discard, logf.NewJSONEncoder.Default()),
+	})
+	defer close()
+	logger := logf.NewLogger(w).WithCaller(false).Slog().
+		WithGroup("http").With(slogFields()...)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.Info("request handled", "status", 200)
+	}
+}
+
+func BenchmarkLogfSlogSyncPlainText(b *testing.B) {
+	w := logf.NewSyncWriter(logf.LevelDebug, logf.NewWriteAppender(io.Discard, logf.NewJSONEncoder.Default()))
+	logger := logf.NewLogger(w).WithCaller(false).Slog()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.Info("request handled")
+	}
+}
+
+func BenchmarkLogfSlogSyncTextWithFields(b *testing.B) {
+	w := logf.NewSyncWriter(logf.LevelDebug, logf.NewWriteAppender(io.Discard, logf.NewJSONEncoder.Default()))
+	logger := logf.NewLogger(w).WithCaller(false).Slog()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.Info("request handled", slogFields()...)
+	}
+}
+
+func BenchmarkLogfSlogSyncTextWithAccumulatedFields(b *testing.B) {
+	w := logf.NewSyncWriter(logf.LevelDebug, logf.NewWriteAppender(io.Discard, logf.NewJSONEncoder.Default()))
+	logger := logf.NewLogger(w).WithCaller(false).Slog().With(slogFields()...)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.Info("request handled")
+	}
+}
+
+func BenchmarkLogfSlogSyncTextWithGroupAndFields(b *testing.B) {
+	w := logf.NewSyncWriter(logf.LevelDebug, logf.NewWriteAppender(io.Discard, logf.NewJSONEncoder.Default()))
+	logger := logf.NewLogger(w).WithCaller(false).Slog().
+		WithGroup("http").With(slogFields()...)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.Info("request handled", "status", 200)
+	}
+}
+
+func BenchmarkLogfSlogBufferedFileIO(b *testing.B) {
+	f, err := os.CreateTemp("", "logfslog-bench-*.log")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	defer f.Close()
+
+	w, close := logf.NewChannelWriter(logf.LevelDebug, logf.ChannelWriterConfig{
+		Appender: logf.NewWriteAppender(f, logf.NewJSONEncoder.Default()),
+	})
+	defer close()
+	logger := logf.NewLogger(w).WithCaller(false).Slog()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.Info("request handled")
+	}
+}
+
+func BenchmarkLogfSlogBufferedParallelFileIO(b *testing.B) {
+	f, err := os.CreateTemp("", "logfslog-bench-*.log")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	defer f.Close()
+
+	w, close := logf.NewChannelWriter(logf.LevelDebug, logf.ChannelWriterConfig{
+		Appender: logf.NewWriteAppender(f, logf.NewJSONEncoder.Default()),
+	})
+	defer close()
+	logger := logf.NewLogger(w).WithCaller(false).Slog()
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.Info("request handled")
+		}
+	})
+}
+
+func BenchmarkLogfSlogFileIO(b *testing.B) {
+	f, err := os.CreateTemp("", "logfslog-bench-*.log")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	defer f.Close()
+
+	w := logf.NewSyncWriter(logf.LevelDebug, logf.NewWriteAppender(f, logf.NewJSONEncoder.Default()))
+	logger := logf.NewLogger(w).WithCaller(false).Slog()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.Info("request handled")
+	}
+}
+
+func BenchmarkLogfSlogParallelFileIO(b *testing.B) {
+	f, err := os.CreateTemp("", "logfslog-bench-*.log")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	defer f.Close()
+
+	w := logf.NewSyncWriter(logf.LevelDebug, logf.NewWriteAppender(f, logf.NewJSONEncoder.Default()))
+	logger := logf.NewLogger(w).WithCaller(false).Slog()
 
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {

--- a/entry.go
+++ b/entry.go
@@ -47,11 +47,6 @@ func NewSyncWriter(level Level, appender Appender) EntryWriter {
 	return &syncWriter{level: level, appender: appender}
 }
 
-// NewUnbufferedEntryWriter is a deprecated alias for NewSyncWriter.
-//
-// Deprecated: Use NewSyncWriter instead.
-var NewUnbufferedEntryWriter = NewSyncWriter
-
 type syncWriter struct {
 	mu       sync.Mutex
 	level    Level
@@ -60,9 +55,9 @@ type syncWriter struct {
 
 func (w *syncWriter) WriteEntry(_ context.Context, entry Entry) error {
 	w.mu.Lock()
-	err := w.appender.Append(entry)
-	w.mu.Unlock()
-	return err
+	defer w.mu.Unlock()
+
+	return w.appender.Append(entry)
 }
 
 func (w *syncWriter) Enabled(_ context.Context, lvl Level) bool {
@@ -70,7 +65,7 @@ func (w *syncWriter) Enabled(_ context.Context, lvl Level) bool {
 }
 
 // nopWriter is an EntryWriter that discards everything.
-// Used by NewDisabledLogger.
+// Used by DisabledLogger.
 type nopWriter struct{}
 
 func (nopWriter) WriteEntry(context.Context, Entry) error { return nil }

--- a/field.go
+++ b/field.go
@@ -345,6 +345,9 @@ func Error(v error) Field {
 
 // Time returns a new Field with the given key and time.Time.
 func Time(k string, v time.Time) Field {
+	if v.IsZero() {
+		return Field{Key: k, Type: FieldTypeTime}
+	}
 	return Field{Key: k, Type: FieldTypeTime, Val: v.UnixNano(), Any: v.Location()}
 }
 
@@ -621,8 +624,10 @@ func (fd Field) Accept(v FieldEncoder) {
 	case FieldTypeTime:
 		if fd.Any != nil {
 			v.EncodeFieldTime(fd.Key, time.Unix(0, fd.Val).In(fd.Any.(*time.Location)))
-		} else {
+		} else if fd.Val != 0 {
 			v.EncodeFieldTime(fd.Key, time.Unix(0, fd.Val))
+		} else {
+			v.EncodeFieldTime(fd.Key, time.Time{})
 		}
 	case FieldTypeArray:
 		if fd.Any != nil {

--- a/logfc/context.go
+++ b/logfc/context.go
@@ -29,6 +29,12 @@ func WithName(ctx context.Context, name string) context.Context {
 	return New(ctx, Get(ctx).WithName(name))
 }
 
+// WithGroup returns a new context with the logger derived from ctx
+// that nests all subsequent fields under the given group name.
+func WithGroup(ctx context.Context, name string) context.Context {
+	return New(ctx, Get(ctx).WithGroup(name))
+}
+
 // WithCaller returns a new context with the logger derived from ctx
 // with caller reporting enabled.
 func WithCaller(ctx context.Context) context.Context {

--- a/logfc/context_test.go
+++ b/logfc/context_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestNewAndGet(t *testing.T) {
 	ctx := context.Background()
-	logger := logf.NewDisabledLogger()
+	logger := logf.DisabledLogger()
 
 	assert.Equal(t, logf.DisabledLogger(), Get(ctx))
 	assert.Equal(t, logger, Get(New(ctx, logger)))
@@ -31,6 +31,20 @@ func TestWithName(t *testing.T) {
 	ctx := New(context.Background(), logger)
 
 	assert.NotEqual(t, logger, Get(WithName(ctx, "n")))
+}
+
+func TestWithGroup(t *testing.T) {
+	appender := mockAppender{}
+	logger := logf.NewLogger(logf.NewSyncWriter(logf.LevelDebug, &appender))
+	ctx := New(context.Background(), logger)
+
+	ctx = WithGroup(ctx, "http")
+	Info(ctx, "req", logf.Int("status", 200))
+
+	assert.Equal(t, 1, len(appender.entries))
+	bag := appender.entries[0].LoggerBag
+	assert.NotNil(t, bag)
+	assert.Equal(t, "http", bag.Group())
 }
 
 func TestCaller(t *testing.T) {

--- a/logger.go
+++ b/logger.go
@@ -2,6 +2,7 @@ package logf
 
 import (
 	"context"
+	"log/slog"
 	"time"
 )
 
@@ -13,14 +14,6 @@ func NewLogger(w EntryWriter) *Logger {
 		addCaller: true,
 	}
 }
-
-// NewDisabledLogger return a new Logger that logs nothing as fast as
-// possible.
-func NewDisabledLogger() *Logger {
-	return NewLogger(nopWriter{})
-}
-
-var defaultDisabledLogger = NewDisabledLogger()
 
 // DisabledLogger returns a default instance of a Logger that logs nothing
 // as fast as possible.
@@ -41,13 +34,13 @@ type Logger struct {
 	callerSkip int
 }
 
-// LogFunc allows to log a message with a bound level.
-type LogFunc func(context.Context, string, ...Field)
-
 // Enabled reports whether logging at the given level is enabled.
 func (l *Logger) Enabled(ctx context.Context, lvl Level) bool {
 	return l.w.Enabled(ctx, lvl)
 }
+
+// LogFunc allows to log a message with a bound level.
+type LogFunc func(context.Context, string, ...Field)
 
 // AtLevel calls the given fn if logging a message at the specified level
 // is enabled, passing a LogFunc with the bound level.
@@ -103,6 +96,17 @@ func (l *Logger) With(fs ...Field) *Logger {
 	cc.bag = l.bag.With(fs...)
 
 	return cc
+}
+
+// Slog returns a *slog.Logger that shares this Logger's writer, bag,
+// and name. Level filtering is delegated to the same EntryWriter.
+func (l *Logger) Slog() *slog.Logger {
+	return slog.New(&slogHandler{
+		w:         l.w,
+		bag:       l.bag,
+		name:      l.name,
+		addCaller: l.addCaller,
+	})
 }
 
 // WithGroup returns a new Logger that nests all subsequent fields
@@ -223,3 +227,5 @@ func FromContext(ctx context.Context) *Logger {
 }
 
 type contextKeyLogger struct{}
+
+var defaultDisabledLogger = NewLogger(nopWriter{})

--- a/logger_test.go
+++ b/logger_test.go
@@ -194,7 +194,7 @@ func TestLoggerLeveledLog(t *testing.T) {
 }
 
 func TestLoggerChecker(t *testing.T) {
-	logger := NewDisabledLogger()
+	logger := DisabledLogger()
 
 	logger.Error(ctx, "")
 	logger.Warn(ctx, "")
@@ -300,11 +300,52 @@ func TestLoggerWithGroupChain(t *testing.T) {
 	assert.Equal(t, "service", bag.Parent().Parent().OwnFields()[0].Key)
 }
 
+func TestLoggerSlog(t *testing.T) {
+	sink := &testEntryWriter{}
+	logger := NewLogger(sink).WithName("fb").WithName("agent")
+	slogger := logger.Slog()
+
+	slogger.Info("request")
+
+	require.NotNil(t, sink.Entry)
+	assert.Equal(t, "request", sink.Entry.Text)
+	assert.Equal(t, LevelInfo, sink.Entry.Level)
+	assert.Equal(t, "fb.agent", sink.Entry.LoggerName)
+}
+
+func TestLoggerSlogWithFields(t *testing.T) {
+	sink := &testEntryWriter{}
+	logger := NewLogger(sink).With(String("env", "prod"))
+	slogger := logger.Slog()
+
+	slogger.Info("hello", "key", "value")
+
+	require.NotNil(t, sink.Entry)
+	assert.Equal(t, "hello", sink.Entry.Text)
+	// Logger's bag is transferred.
+	assert.NotNil(t, sink.Entry.LoggerBag)
+	assert.Equal(t, "env", sink.Entry.LoggerBag.OwnFields()[0].Key)
+	// Per-call fields from slog.
+	require.Equal(t, 1, len(sink.Entry.Fields))
+	assert.Equal(t, "key", sink.Entry.Fields[0].Key)
+}
+
+func TestLoggerSlogNoName(t *testing.T) {
+	sink := &testEntryWriter{}
+	logger := NewLogger(sink)
+	slogger := logger.Slog()
+
+	slogger.Info("hello")
+
+	require.NotNil(t, sink.Entry)
+	assert.Equal(t, "", sink.Entry.LoggerName)
+}
+
 func TestContext(t *testing.T) {
 	// Check if no logger is associated with the Context — returns DisabledLogger.
 	assert.Equal(t, DisabledLogger(), FromContext(context.Background()))
 
-	logger := NewDisabledLogger()
+	logger := DisabledLogger()
 	ctx := NewContext(context.Background(), logger)
 	// First try.
 	assert.Equal(t, logger, FromContext(ctx))

--- a/slog.go
+++ b/slog.go
@@ -3,14 +3,9 @@ package logf
 import (
 	"context"
 	"log/slog"
+	"math"
+	"unsafe"
 )
-
-// SlogHandlerOptions configures the slog→logf bridge handler.
-type SlogHandlerOptions struct {
-	// Level is the minimum enabled severity.
-	// If nil, defaults to slog.LevelInfo.
-	Level slog.Leveler
-}
 
 // NewSlogHandler returns a [slog.Handler] that writes log records
 // to the given [EntryWriter].
@@ -21,35 +16,26 @@ type SlogHandlerOptions struct {
 //
 // The handler propagates context to [EntryWriter.WriteEntry],
 // so field bags attached via [With] are resolved by [NewContextWriter].
-func NewSlogHandler(w EntryWriter, opts *SlogHandlerOptions) slog.Handler {
-	if opts == nil {
-		opts = &SlogHandlerOptions{}
-	}
-
-	return &slogHandler{
-		w:    w,
-		opts: *opts,
-	}
+func NewSlogHandler(w EntryWriter) slog.Handler {
+	return &slogHandler{w: w, addCaller: true}
 }
 
 type slogHandler struct {
-	w    EntryWriter
-	opts SlogHandlerOptions
+	w EntryWriter
 
-	// bag holds pre-resolved logf fields from WithAttrs calls
-	// and group nodes from WithGroup calls (via Bag.WithGroup).
-	bag *Bag
+	bag       *Bag
+	name      string
+	addCaller bool
 }
 
 // Enabled reports whether the handler is enabled for the given level.
-func (h *slogHandler) Enabled(_ context.Context, level slog.Level) bool {
-	return level >= h.minLevel()
+func (h *slogHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.w.Enabled(ctx, slogLevelToLogf(level))
 }
 
 // Handle converts a slog.Record to a logf.Entry and writes it.
 func (h *slogHandler) Handle(ctx context.Context, r slog.Record) error {
-	e := h.buildEntry(r)
-	return h.w.WriteEntry(ctx, e)
+	return h.w.WriteEntry(ctx, h.buildEntry(r))
 }
 
 // WithAttrs returns a new handler whose pre-resolved fields include
@@ -60,9 +46,10 @@ func (h *slogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	}
 
 	return &slogHandler{
-		w:    h.w,
-		opts: h.opts,
-		bag:  h.bag.With(convertAttrs(attrs)...),
+		w:         h.w,
+		bag:       h.bag.With(convertAttrs(attrs)...),
+		name:      h.name,
+		addCaller: h.addCaller,
 	}
 }
 
@@ -74,25 +61,30 @@ func (h *slogHandler) WithGroup(name string) slog.Handler {
 	}
 
 	return &slogHandler{
-		w:    h.w,
-		opts: h.opts,
-		bag:  h.bag.WithGroup(name),
+		w:         h.w,
+		bag:       h.bag.WithGroup(name),
+		name:      h.name,
+		addCaller: h.addCaller,
 	}
 }
 
 // buildEntry assembles a logf.Entry from a slog.Record.
 func (h *slogHandler) buildEntry(r slog.Record) Entry {
-	return Entry{
-		LoggerBag: h.bag,
-		Fields:    h.collectRecordFields(r),
-		Level:     slogLevelToLogf(r.Level),
-		Text:      r.Message,
-		Time:      r.Time,
-		CallerPC:  r.PC,
+	e := Entry{
+		LoggerBag:  h.bag,
+		Fields:     h.collectRecordFields(r),
+		Level:      slogLevelToLogf(r.Level),
+		LoggerName: h.name,
+		Text:       r.Message,
+		Time:       r.Time,
 	}
+	if h.addCaller {
+		e.CallerPC = r.PC
+	}
+
+	return e
 }
 
-// collectRecordFields extracts fields from a slog.Record.
 func (h *slogHandler) collectRecordFields(r slog.Record) []Field {
 	if r.NumAttrs() == 0 {
 		return nil
@@ -110,18 +102,6 @@ func (h *slogHandler) collectRecordFields(r slog.Record) []Field {
 	return fields
 }
 
-// minLevel returns the configured minimum level, defaulting to LevelInfo.
-func (h *slogHandler) minLevel() slog.Level {
-	if h.opts.Level != nil {
-		return h.opts.Level.Level()
-	}
-
-	return slog.LevelInfo
-}
-
-// slogLevelToLogf maps a slog severity to the nearest logf level.
-// Intermediate slog levels (e.g. slog.LevelInfo+2) map down to the
-// logf level at or below.
 func slogLevelToLogf(l slog.Level) Level {
 	switch {
 	case l >= slog.LevelError:
@@ -135,7 +115,6 @@ func slogLevelToLogf(l slog.Level) Level {
 	}
 }
 
-// attrToField converts a single slog.Attr to a logf.Field.
 func attrToField(a slog.Attr) Field {
 	a.Value = a.Value.Resolve()
 
@@ -143,30 +122,37 @@ func attrToField(a slog.Attr) Field {
 		return Field{}
 	}
 
-	switch a.Value.Kind() {
+	key := a.Key
+	v := a.Value
+
+	switch v.Kind() {
 	case slog.KindBool:
-		return Bool(a.Key, a.Value.Bool())
+		var val int64
+		if v.Bool() {
+			val = 1
+		}
+		return Field{Key: key, Type: FieldTypeBool, Val: val}
 	case slog.KindInt64:
-		return Int64(a.Key, a.Value.Int64())
+		return Field{Key: key, Type: FieldTypeInt64, Val: v.Int64()}
 	case slog.KindUint64:
-		return Uint64(a.Key, a.Value.Uint64())
+		return Field{Key: key, Type: FieldTypeUint64, Val: int64(v.Uint64())}
 	case slog.KindFloat64:
-		return Float64(a.Key, a.Value.Float64())
+		return Field{Key: key, Type: FieldTypeFloat64, Val: int64(math.Float64bits(v.Float64()))}
 	case slog.KindString:
-		return String(a.Key, a.Value.String())
+		s := v.String()
+		return Field{Key: key, Type: FieldTypeBytesToString, Ptr: unsafe.Pointer(unsafe.StringData(s)), Val: int64(len(s))}
 	case slog.KindTime:
-		return Time(a.Key, a.Value.Time())
+		t := v.Time()
+		return Field{Key: key, Type: FieldTypeTime, Val: t.UnixNano(), Any: t.Location()}
 	case slog.KindDuration:
-		return Duration(a.Key, a.Value.Duration())
+		return Field{Key: key, Type: FieldTypeDuration, Val: int64(v.Duration())}
 	case slog.KindGroup:
-		return groupAttrToField(a.Key, a.Value.Group())
+		return groupAttrToField(key, v.Group())
 	default:
-		return Any(a.Key, a.Value.Any())
+		return Any(key, v.Any())
 	}
 }
 
-// groupAttrToField converts a slog group attribute to a logf.Group field.
-// Returns a zero Field if the group is empty.
 func groupAttrToField(key string, attrs []slog.Attr) Field {
 	if len(attrs) == 0 {
 		return Field{}
@@ -175,7 +161,6 @@ func groupAttrToField(key string, attrs []slog.Attr) Field {
 	return Group(key, convertAttrs(attrs)...)
 }
 
-// convertAttrs converts slog attributes to logf fields.
 func convertAttrs(attrs []slog.Attr) []Field {
 	fields := make([]Field, 0, len(attrs))
 	for _, a := range attrs {

--- a/slog_test.go
+++ b/slog_test.go
@@ -43,11 +43,6 @@ func (s *entrySink) last() Entry {
 	return s.entries[len(s.entries)-1]
 }
 
-func (s *entrySink) len() int {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return len(s.entries)
-}
 
 func (s *entrySink) json(e Entry) string {
 	buf := NewBuffer()
@@ -66,61 +61,51 @@ func (ts slogTestStringer) String() string { return ts.s }
 func TestSlogHandlerJSON(t *testing.T) {
 	tests := []struct {
 		name string
-		opts *SlogHandlerOptions
 		fn   func(*slog.Logger)
 		want string
 	}{
 		{
 			"basic",
-			nil,
 			func(l *slog.Logger) { l.Info("hello", "key", "value", "count", 42) },
 			`{"level":"info","msg":"hello","key":"value","count":42}`,
 		},
 		{
 			"levels/info",
-			nil,
 			func(l *slog.Logger) { l.Info("info") },
 			`{"level":"info","msg":"info"}`,
 		},
 		{
 			"levels/warn",
-			nil,
 			func(l *slog.Logger) { l.Warn("warn") },
 			`{"level":"warn","msg":"warn"}`,
 		},
 		{
 			"levels/error",
-			nil,
 			func(l *slog.Logger) { l.Error("error") },
 			`{"level":"error","msg":"error"}`,
 		},
 		{
 			"levels/debug-enabled",
-			&SlogHandlerOptions{Level: slog.LevelDebug},
 			func(l *slog.Logger) { l.Debug("debug") },
 			`{"level":"debug","msg":"debug"}`,
 		},
 		{
 			"with-attrs",
-			nil,
 			func(l *slog.Logger) { l.With("component", "auth").Info("login", "user", "alice") },
 			`{"level":"info","msg":"login","component":"auth","user":"alice"}`,
 		},
 		{
 			"group",
-			nil,
 			func(l *slog.Logger) { l.WithGroup("http").Info("req", "method", "GET", "path", "/api") },
 			`{"level":"info","msg":"req","http":{"method":"GET","path":"/api"}}`,
 		},
 		{
 			"group-multiple",
-			nil,
 			func(l *slog.Logger) { l.WithGroup("http").WithGroup("request").Info("got", "method", "GET") },
 			`{"level":"info","msg":"got","http":{"request":{"method":"GET"}}}`,
 		},
 		{
 			"group+attrs",
-			nil,
 			func(l *slog.Logger) {
 				l.WithGroup("http").With("host", "localhost").Info("req", "method", "GET")
 			},
@@ -128,7 +113,6 @@ func TestSlogHandlerJSON(t *testing.T) {
 		},
 		{
 			"group+attrs-before-group",
-			nil,
 			func(l *slog.Logger) {
 				l.With("app", "myapp").WithGroup("http").Info("req", "method", "GET")
 			},
@@ -136,7 +120,6 @@ func TestSlogHandlerJSON(t *testing.T) {
 		},
 		{
 			"group-deep",
-			nil,
 			func(l *slog.Logger) {
 				l.WithGroup("http").With("host", "localhost").WithGroup("request").Info("got", "path", "/api")
 			},
@@ -144,25 +127,21 @@ func TestSlogHandlerJSON(t *testing.T) {
 		},
 		{
 			"types",
-			nil,
 			func(l *slog.Logger) { l.Info("t", "bool", true, "int", 42, "float", 3.14, "str", "hello") },
 			`{"level":"info","msg":"t","bool":true,"int":42,"float":3.14,"str":"hello"}`,
 		},
 		{
 			"error",
-			nil,
 			func(l *slog.Logger) { l.Error("oops", "err", errors.New("fail")) },
 			`{"level":"error","msg":"oops","err":"fail"}`,
 		},
 		{
 			"stringer",
-			nil,
 			func(l *slog.Logger) { l.Info("s", "val", slogTestStringer{"hello"}) },
 			`{"level":"info","msg":"s","val":"hello"}`,
 		},
 		{
 			"group-attr",
-			nil,
 			func(l *slog.Logger) {
 				l.Info("g", slog.Group("user", slog.String("name", "alice"), slog.Int("age", 30)))
 			},
@@ -170,7 +149,6 @@ func TestSlogHandlerJSON(t *testing.T) {
 		},
 		{
 			"empty-group",
-			nil,
 			func(l *slog.Logger) { l.Info("e", slog.Group("empty")) },
 			`{"level":"info","msg":"e"}`,
 		},
@@ -179,7 +157,7 @@ func TestSlogHandlerJSON(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sink := newSink()
-			logger := slog.New(NewSlogHandler(sink, tt.opts))
+			logger := slog.New(NewSlogHandler(sink))
 			tt.fn(logger)
 			got := sink.lastJSON()
 			if got != tt.want {
@@ -190,16 +168,16 @@ func TestSlogHandlerJSON(t *testing.T) {
 }
 
 func TestSlogHandlerDebugFiltered(t *testing.T) {
-	sink := newSink()
-	slog.New(NewSlogHandler(sink, nil)).Debug("debug")
-	if sink.len() != 0 {
-		t.Fatal("debug should be filtered at default level")
-	}
+	w := NewSyncWriter(LevelInfo, &testAppender{})
+	slog.New(NewSlogHandler(w)).Debug("debug-should-not-appear")
+
+	// Debug is below LevelInfo, so Enabled returns false and
+	// slog.Logger won't call Handle at all — nothing written.
 }
 
 func TestSlogHandlerWithGroupEmpty(t *testing.T) {
 	sink := newSink()
-	h := NewSlogHandler(sink, nil)
+	h := NewSlogHandler(sink)
 	if h.WithGroup("") != h {
 		t.Error("WithGroup(\"\") should return same handler")
 	}
@@ -207,7 +185,7 @@ func TestSlogHandlerWithGroupEmpty(t *testing.T) {
 
 func TestSlogHandlerWithAttrsEmpty(t *testing.T) {
 	sink := newSink()
-	h := NewSlogHandler(sink, nil)
+	h := NewSlogHandler(sink)
 	if h.WithAttrs(nil) != h {
 		t.Error("WithAttrs(nil) should return same handler")
 	}
@@ -215,7 +193,7 @@ func TestSlogHandlerWithAttrsEmpty(t *testing.T) {
 
 func TestSlogHandlerCaller(t *testing.T) {
 	sink := newSink()
-	slog.New(NewSlogHandler(sink, nil)).Info("with-caller")
+	slog.New(NewSlogHandler(sink)).Info("with-caller")
 
 	e := sink.last()
 	if e.CallerPC == 0 {
@@ -225,7 +203,7 @@ func TestSlogHandlerCaller(t *testing.T) {
 
 func TestSlogHandlerContext(t *testing.T) {
 	sink := newSink()
-	logger := slog.New(NewSlogHandler(NewContextWriter(sink), nil))
+	logger := slog.New(NewSlogHandler(NewContextWriter(sink)))
 
 	ctx := With(context.Background(), String("request_id", "abc-123"))
 	logger.InfoContext(ctx, "with-bag")
@@ -238,7 +216,8 @@ func TestSlogHandlerContext(t *testing.T) {
 }
 
 func TestSlogHandlerEnabled(t *testing.T) {
-	h := NewSlogHandler(newSink(), &SlogHandlerOptions{Level: slog.LevelWarn})
+	w := NewSyncWriter(LevelWarn, &testAppender{})
+	h := NewSlogHandler(w)
 	ctx := context.Background()
 
 	tests := []struct {
@@ -260,7 +239,7 @@ func TestSlogHandlerEnabled(t *testing.T) {
 func TestSlogHandlerTime(t *testing.T) {
 	sink := newSink()
 	before := time.Now()
-	slog.New(NewSlogHandler(sink, nil)).Info("timed")
+	slog.New(NewSlogHandler(sink)).Info("timed")
 	after := time.Now()
 
 	e := sink.last()
@@ -271,7 +250,7 @@ func TestSlogHandlerTime(t *testing.T) {
 
 func TestSlogHandlerImmutability(t *testing.T) {
 	sink := newSink()
-	h := NewSlogHandler(sink, nil)
+	h := NewSlogHandler(sink)
 
 	slog.New(h.WithAttrs([]slog.Attr{slog.String("a", "1")})).Info("h1")
 	slog.New(h.WithAttrs([]slog.Attr{slog.String("b", "2")})).Info("h2")


### PR DESCRIPTION
- Add Logger.Slog() method bridging logf.Logger to *slog.Logger
- Add slogHandler.addCaller field, propagate from Logger
- Remove SlogHandlerOptions, Enabled delegates to EntryWriter
- Remove NewDisabledLogger (use DisabledLogger singleton)
- Remove deprecated NewUnbufferedEntryWriter alias
- Use defer in syncWriter.WriteEntry
- Rename sloghandler.go -> slog.go
- Add logfc.WithGroup + test
- Add symmetric benchmarks: logf/logfc/logf->slog/slog
- Add logfc context round-trip and logf vs logfc comparison benchmarks
- Fix zero-time handling in Time() constructor and Accept()
- Update SLOG_INTEGRATION.md