### PR TITLE
fix(field): move fmt.Stringer before reflect in Any() to prevent secret leaking

### DIFF
--- a/field.go
+++ b/field.go
@@ -320,6 +320,12 @@ func Any(k string, v interface{}) Field {
 		return Array(k, rv)
 	case ObjectEncoder:
 		return Object(k, rv)
+	// fmt.Stringer MUST stay after concrete types (time.Duration, error, etc.)
+	// and before default. Moving it earlier would shadow typed handling;
+	// moving it into default would let reflect.String leak raw values
+	// from types that implement Stringer for masking (e.g. secrets).
+	case fmt.Stringer:
+		return String(k, rv.String())
 
 	case nil:
 		break
@@ -340,9 +346,6 @@ func Any(k string, v interface{}) Field {
 			return Uint64(k, val.Uint())
 		case reflect.Float32, reflect.Float64:
 			return Float64(k, val.Float())
-		}
-		if s, ok := rv.(fmt.Stringer); ok {
-			return String(k, s.String())
 		}
 	}
 

--- a/field_test.go
+++ b/field_test.go
@@ -284,6 +284,35 @@ func TestFieldByteString(t *testing.T) {
 	assert.Equal(t, "hello", e.result["k"])
 }
 
+// secretToken implements fmt.Stringer to mask its value in logs.
+type secretToken string
+
+func (t secretToken) String() string {
+	if len(t) > 4 {
+		return string(t[:2]) + "***"
+	}
+	return "***"
+}
+
+func TestFieldMasking(t *testing.T) {
+	raw := secretToken("eyJhbGciOiJSUzI1NiJ9.secret")
+
+	t.Run("Stringer", func(t *testing.T) {
+		e := newTestFieldEncoder()
+		f := Stringer("token", raw)
+		f.Accept(e)
+		assert.Equal(t, "ey***", e.result["token"])
+		assert.NotContains(t, e.result["token"], "secret")
+	})
+	t.Run("Any", func(t *testing.T) {
+		e := newTestFieldEncoder()
+		f := Any("token", raw)
+		f.Accept(e)
+		assert.Equal(t, "ey***", e.result["token"])
+		assert.NotContains(t, e.result["token"], "secret")
+	})
+}
+
 func TestFieldNamedError(t *testing.T) {
 	golden := errors.New("named error")
 


### PR DESCRIPTION
Any() for named string types implementing fmt.Stringer (e.g. secret tokens with masked String()) was hitting reflect.String first, returning the raw underlying value instead of the masked representation.

Move fmt.Stringer check into the main type switch after concrete types and before default/reflect. Add TestFieldMasking regression test.