### PR TITLE
feat: add WriterSlot, fix SlabWriter message integrity and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,27 +5,55 @@
 [![Go Report Status](https://goreportcard.com/badge/github.com/ssgreg/logf)](https://goreportcard.com/report/github.com/ssgreg/logf)
 [![Coverage Status](https://codecov.io/gh/ssgreg/logf/branch/master/graph/badge.svg)](https://codecov.io/gh/ssgreg/logf)
 
-Async structured logging for Go. Fast, resilient, slog-compatible.
+Structured logging for Go — context-aware, slog-native, fast.
+
+## Features
+
+- **Context-aware fields** — `logf.With(ctx, fields...)` attaches fields to context, automatically included in every log entry
+- **Native slog bridge** — `logger.Slog()` returns a `*slog.Logger` sharing the same pipeline, fields, and name. Passes `testing/slogtest`
+- **Router** — multi-destination fan-out with per-output level filtering and encoder groups
+- **Async buffered I/O** — SlabWriter with pre-allocated slab pool, zero per-message allocations
+- **Builder API** — `logf.NewLogger().Level(logf.LevelInfo).Build()` for quick setup
+- **Zero-alloc hot path** — 0 allocs/op across all benchmarks
+
+## Quick Start
+
+```go
+// Minimal — JSON to stderr:
+logger := logf.NewLogger().Build()
+
+// Production — custom encoder, stdout:
+logger := logf.NewLogger().
+    Level(logf.LevelInfo).
+    Output(os.Stdout).
+    EncoderFrom(logf.JSON().TimeKey("time")).
+    Context().
+    Build()
+
+// slog backend:
+slogger := logger.Slog()
+```
 
 ## Why logf
 
 slog from the standard library is sufficient for most applications. logf targets
 scenarios where slog falls short:
 
-- **High-throughput logging (>100K logs/sec)** — logf's buffered file I/O is 2×
-  faster than slog (285 ns/op vs 518 ns/op) due to built-in write batching.
+- **High-throughput logging (>100K logs/sec)** — encoding is parallel across
+  goroutines (no global mutex), writes are memcpy into pre-allocated slabs
+  (~17 ns), and a background goroutine flushes large blocks. Result: 2× faster
+  than slog (285 ns/op vs 518 ns/op) under parallel file I/O.
 - **Unstable I/O / spike protection** — under simulated slow disk (2% of writes
   sleep 1ms), slog p99 = 2.5ms while logf p99 = 71µs. slog holds a mutex over
   the entire `Handle()` call (encode + write), causing cascading delays under
-  contention. logf's async channel decouples callers from I/O entirely.
+  contention. logf's slab pool decouples callers from I/O entirely.
 - **Request-scoped fields via context** — `logf.With(ctx, fields...)` attaches
   fields to `context.Context` that are automatically included in every log entry.
   Neither slog nor zap support this natively; they require passing a derived
   logger through the call stack.
-- **Decoupled encoding and I/O** — logf is the only Go logger where encoding
-  and writing are fully separated. This enables async writes, multiple encoders
-  per destination, and per-destination isolation in a single pipeline. The caller
-  goroutine encodes in parallel and never blocks on `write(fd)`.
+- **Decoupled encoding and I/O** — the Router encodes once per encoder group
+  and fans out to multiple writers. Each writer can be sync or async (SlabWriter)
+  independently. A stalled network destination does not block file writes.
 
 ## Design Philosophy
 
@@ -283,7 +311,7 @@ their application code.
 logger := slog.New(slog.NewJSONHandler(file, nil))
 
 // slog + logf backend — async, buffered, same API
-enc := logf.NewJSONEncoder(logf.JSONEncoderConfig{})
+enc := logf.JSON().Build()
 sw := logf.NewSlabWriter(file, 64*1024, 8)
 defer sw.Close()
 h, close, _ := logf.NewRouter().
@@ -298,7 +326,13 @@ it is an infrastructure layer behind the standard one. Think of it as choosing
 nginx vs another HTTP server: the HTTP interface is the same, but the backend
 determines throughput, latency, and resilience.
 
-**Context-scoped fields** are a unique logf feature available through the slog handler.
+**`Logger.Slog()` produces a fully integrated `*slog.Logger`** — not a separate
+logger, but a view of the same pipeline. It inherits accumulated `.With()` fields,
+`.WithName()` identity, and the full Handler chain (Router, ContextHandler, etc.).
+Logging via slog and logf in the same request produces identical context fields,
+the same encoder, the same destination. There is no state divergence.
+
+**Context-scoped fields** work through the slog handler as well.
 Middleware can attach fields to `context.Context` via `logf.With(ctx, fields...)`,
 and the handler automatically includes them in every log entry — without passing
 a derived logger through the call stack. Neither zap nor standard slog support this.

--- a/benchmarks/fileparallel_test.go
+++ b/benchmarks/fileparallel_test.go
@@ -192,7 +192,7 @@ func BenchmarkFileParallel_Logf_Slab64Kx4_Drop(b *testing.B) {
 	_ = closeFn()
 	_ = sw.Close()
 
-	b.ReportMetric(float64(sw.Dropped()), "drops")
+	b.ReportMetric(float64(sw.Stats().Dropped), "drops")
 }
 
 func BenchmarkFileParallel_Logf_Slab64Kx1(b *testing.B) {
@@ -258,5 +258,5 @@ func BenchmarkFileParallel_Logf_Slab64Kx2_Drop(b *testing.B) {
 	_ = closeFn()
 	_ = sw.Close()
 
-	b.ReportMetric(float64(sw.Dropped()), "drops")
+	b.ReportMetric(float64(sw.Stats().Dropped), "drops")
 }

--- a/slabwriter.go
+++ b/slabwriter.go
@@ -86,7 +86,38 @@ const (
 // silently discarded and the slab is reused. Use Dropped to monitor
 // the total number of messages lost.
 //
-// Concurrency: Write and Flush are safe for concurrent use.
+// # Message integrity
+//
+// Write guarantees that each message is either fully delivered or
+// fully dropped — never partially written (torn). This holds for
+// messages of any size:
+//
+//   - len(p) <= slabSize: if the message does not fit in the remaining
+//     slab space, an early swap is performed before writing. The message
+//     always lands in a single slab. On drop the entire slab (including
+//     the message) is discarded atomically.
+//
+//   - len(p) > slabSize: the message is allocated in a dedicated
+//     oversized buffer and sent through the I/O goroutine as a single
+//     write. The oversized buffer is discarded after write (not returned
+//     to the pool). One allocation per oversized message.
+//
+// # Performance notes
+//
+// The early swap may leave unused space at the tail of a slab when a
+// message does not fit in the remainder. With typical log messages
+// (200–500 bytes) and slab sizes (16–64 KB), utilization stays above
+// 99 %. Fragmentation becomes noticeable only when message size
+// approaches slab size (e.g. msg/slab > 50 %), which is unusual for
+// structured logging.
+//
+// Oversized messages (> slabSize) incur one heap allocation (make +
+// copy) per write. This is acceptable because such messages are rare;
+// typical log entries are 100–500 bytes while the default slab is 4 KB.
+//
+// # Concurrency
+//
+// Write and Flush are safe for concurrent use.
 // Write and Flush must not be called after or concurrently with Close.
 // Close itself is idempotent.
 type SlabWriter struct {
@@ -107,8 +138,8 @@ type SlabWriter struct {
 	closeErr      error         // Flush/Sync errors from drain; set before done is closed
 	closeOnce     sync.Once     // prevents double-close panic
 	dropOnFull    bool          // if true, drop data instead of blocking on full pool
-	dropped       atomic.Int64  // total messages dropped (only in dropOnFull mode)
-	written       atomic.Int64  // total messages accepted by Write
+	dropped       int64         // total messages dropped (protected by mu)
+	written       int64         // total messages accepted by Write (protected by mu)
 	writeErrors   atomic.Int64  // total write errors (ioLoop only)
 }
 
@@ -167,7 +198,7 @@ func NewSlabWriter(w io.Writer, slabSize, slabCount int, opts ...SlabOption) *Sl
 	sb := &SlabWriter{
 		slabSize: slabSize,
 		pool:     make(chan []byte, slabCount),
-		full:     make(chan []byte, slabCount),
+		full:     make(chan []byte, slabCount+1), // +1 for occasional oversized message
 		w:        WriterFromIO(w),
 		stop:     make(chan struct{}),
 		done:     make(chan struct{}),
@@ -187,28 +218,41 @@ func NewSlabWriter(w io.Writer, slabSize, slabCount int, opts ...SlabOption) *Sl
 	return sb
 }
 
-// Write copies p into the current slab. When a slab fills up it is
-// sent to the I/O goroutine and a fresh slab is grabbed from the pool.
+// Write copies p into the current slab. Each message is guaranteed to
+// be either fully written or fully dropped (see Message integrity above).
+//
+// If p does not fit in the remaining slab space, an early swap is
+// performed so the message lands in a fresh slab. If p is larger than
+// slabSize, a dedicated oversized buffer is allocated.
+//
 // Write is safe for concurrent use. It must not be called after Close.
 func (sb *SlabWriter) Write(p []byte) (int, error) {
 	sb.mu.Lock()
-	written := 0
-	for written < len(p) {
-		avail := sb.slabSize - sb.pos
-		if avail == 0 {
-			sb.swapSlab()
-			avail = sb.slabSize
-		}
-		n := len(p) - written
-		if n > avail {
-			n = avail
-		}
-		copy(sb.current[sb.pos:sb.pos+n], p[written:written+n])
-		sb.pos += n
-		written += n
+	sb.written++
+	if sb.dropOnFull {
+		sb.msgCount++
 	}
-	sb.msgCount++
-	sb.written.Add(1)
+
+	avail := sb.slabSize - sb.pos
+	if len(p) > avail && sb.pos > 0 {
+		// Message doesn't fit in remaining space. Swap early to keep
+		// it in one slab (atomic drop guarantee for msg <= slabSize).
+		if !sb.swapSlab() {
+			sb.mu.Unlock()
+			return len(p), nil // whole message dropped
+		}
+	}
+
+	// Oversized message: use a dedicated buffer to keep it in one piece.
+	if len(p) > sb.slabSize {
+		sb.writeOversized(p)
+		sb.mu.Unlock()
+		return len(p), nil
+	}
+
+	// After early swap, message is guaranteed to fit — direct copy.
+	copy(sb.current[sb.pos:sb.pos+len(p)], p)
+	sb.pos += len(p)
 	sb.mu.Unlock()
 	return len(p), nil
 }
@@ -248,41 +292,44 @@ func (sb *SlabWriter) Close() error {
 	return sb.closeErr
 }
 
-// Dropped returns the total number of messages dropped due to
-// backpressure (only meaningful when WithDropOnFull is enabled).
-// The count is approximate for messages larger than slabSize.
-func (sb *SlabWriter) Dropped() int64 {
-	return sb.dropped.Load()
-}
-
 // Stats returns a snapshot of runtime statistics. Safe to call
-// concurrently from a metrics scraper without blocking Write.
+// concurrently from a metrics scraper. Briefly locks mu to read
+// the written counter (plain int64, not atomic — atomic.Add inside
+// mutex causes cache-line bouncing under parallel load, +22% regression).
 func (sb *SlabWriter) Stats() SlabStats {
+	sb.mu.Lock()
+	written := sb.written
+	dropped := sb.dropped
+	sb.mu.Unlock()
 	return SlabStats{
 		QueuedSlabs: len(sb.full),
 		FreeSlabs:   len(sb.pool),
 		TotalSlabs:  cap(sb.full),
-		Dropped:     sb.dropped.Load(),
-		Written:     sb.written.Load(),
+		Dropped:     dropped,
+		Written:     written,
 		WriteErrors: sb.writeErrors.Load(),
 	}
 }
 
 // swapSlab sends the current slab (trimmed to pos) to the I/O goroutine
-// and grabs a fresh slab from the pool.
+// and grabs a fresh slab from the pool. Returns true on success.
 //
 // In dropOnFull mode the pool is checked first (non-blocking). If a
 // free slab is available, the full send is guaranteed non-blocking by
 // the slab-count invariant (pool + full + processing + current = N).
-// If the pool is empty, the data is dropped and the current slab is reused.
-func (sb *SlabWriter) swapSlab() {
+// If the pool is empty, the data is dropped and the current slab is
+// reused. Returns false so the caller can abort a multi-slab write.
+func (sb *SlabWriter) swapSlab() bool {
 	if sb.dropOnFull {
 		select {
 		case fresh := <-sb.pool:
 			sb.full <- sb.current[:sb.pos]
 			sb.current = fresh
 		default:
-			sb.dropped.Add(int64(sb.msgCount))
+			sb.dropped += int64(sb.msgCount)
+			sb.pos = 0
+			sb.msgCount = 0
+			return false
 		}
 	} else {
 		sb.full <- sb.current[:sb.pos]
@@ -290,6 +337,39 @@ func (sb *SlabWriter) swapSlab() {
 	}
 	sb.pos = 0
 	sb.msgCount = 0
+	return true
+}
+
+// writeOversized handles messages larger than slabSize. It flushes the
+// current partial slab first (to preserve ordering), then writes the
+// oversized message synchronously to the destination. This avoids
+// breaking the slab pool invariant (fixed number of equal-sized slabs).
+// Oversized messages are rare (anomaly for a logger), so the synchronous
+// write is acceptable.
+// Caller must hold mu.
+func (sb *SlabWriter) writeOversized(p []byte) {
+	// Flush current partial slab first to preserve order.
+	if sb.pos > 0 {
+		if !sb.swapSlab() {
+			return // drop mode: pool empty, both current and oversized dropped
+		}
+	}
+
+	// Send oversized message through the full channel. The extra
+	// capacity (+1 in constructor) accommodates one oversized slab
+	// beyond the normal pool. processSlab discards oversized slabs
+	// instead of returning them to the pool.
+	oversized := make([]byte, len(p))
+	copy(oversized, p)
+	if sb.dropOnFull {
+		select {
+		case sb.full <- oversized:
+		default:
+			sb.dropped += int64(1)
+		}
+	} else {
+		sb.full <- oversized
+	}
 }
 
 func (sb *SlabWriter) ioLoop() {
@@ -345,8 +425,13 @@ func stopTimer(t *time.Timer, ch <-chan time.Time) {
 }
 
 // processSlab writes the slab to the destination and recycles it.
+// Oversized slabs (from writeOversized) are discarded — they are
+// extra and must not be returned to the fixed-size pool.
 func (sb *SlabWriter) processSlab(slab []byte) {
 	sb.safeWrite(slab)
+	if cap(slab) != sb.slabSize {
+		return // oversized slab — discard, don't return to pool
+	}
 	sb.pool <- slab[:cap(slab)]
 }
 
@@ -399,7 +484,7 @@ func (sb *SlabWriter) reportError(err error) {
 	sb.errCount++
 	sb.writeErrors.Add(1)
 	if sb.errCount == 1 && sb.errW != nil {
-		fmt.Fprintf(sb.errW, "logf: SlabWriter: %v\n", err)
+		sb.safeReport("logf: SlabWriter: %v\n", err)
 	}
 }
 
@@ -410,12 +495,18 @@ func (sb *SlabWriter) reportOK() {
 	}
 	if sb.errW != nil {
 		if sb.errCount > 1 {
-			fmt.Fprintf(sb.errW, "logf: SlabWriter: recovered after %d errors\n", sb.errCount)
+			sb.safeReport("logf: SlabWriter: recovered after %d errors\n", sb.errCount)
 		} else {
-			fmt.Fprintf(sb.errW, "logf: SlabWriter: recovered\n")
+			sb.safeReport("logf: SlabWriter: recovered\n")
 		}
 	}
 	sb.errCount = 0
+}
+
+// safeReport writes to errW, recovering from panics to avoid crashing ioLoop.
+func (sb *SlabWriter) safeReport(format string, args ...any) {
+	defer func() { _ = recover() }()
+	fmt.Fprintf(sb.errW, format, args...)
 }
 
 func (sb *SlabWriter) drain() {

--- a/slabwriter_bench_test.go
+++ b/slabwriter_bench_test.go
@@ -3,6 +3,7 @@ package logf
 import (
 	"os"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 )
@@ -416,3 +417,170 @@ func (w *slowWriter) Write(p []byte) (int, error) {
 }
 func (w *slowWriter) Flush() error { return nil }
 func (w *slowWriter) Sync() error  { return nil }
+
+// --- Fragmentation benchmarks ---
+
+// BenchmarkSlabBufferNoFragmentation: messages fit evenly into slabs (no wasted space).
+func BenchmarkSlabBufferNoFragmentation(b *testing.B) {
+	slab := NewSlabWriter(discardWriter{}, 64*1024, 8)
+	// 256 bytes fits 256 times into 64KB — zero fragmentation.
+	m := make([]byte, 256)
+
+	b.SetBytes(int64(len(m)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = slab.Write(m)
+	}
+	b.StopTimer()
+	_ = slab.Close()
+}
+
+// BenchmarkSlabBufferFragmentation50Pct: every message triggers early swap
+// because it doesn't fit in the remaining space (~50% slab utilization).
+func BenchmarkSlabBufferFragmentation50Pct(b *testing.B) {
+	// slabSize=512, msg=300 → first msg: 300 bytes written, 212 remain.
+	// second msg: 300 > 212 → early swap (212 bytes wasted = 41%).
+	// Repeated: every other write triggers a swap.
+	slab := NewSlabWriter(discardWriter{}, 512, 8)
+	m := make([]byte, 300)
+
+	b.SetBytes(int64(len(m)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = slab.Write(m)
+	}
+	b.StopTimer()
+	_ = slab.Close()
+}
+
+// BenchmarkSlabBufferFragmentationWorstCase: message = slabSize-1,
+// every write triggers early swap (only 1 byte used per slab on second write).
+func BenchmarkSlabBufferFragmentationWorstCase(b *testing.B) {
+	slabSize := 4096
+	slab := NewSlabWriter(discardWriter{}, slabSize, 8)
+	// msg = slabSize - 1: first write fills 4095, leaves 1 byte.
+	// second write: 4095 > 1 → early swap. ~50% utilization.
+	m := make([]byte, slabSize-1)
+
+	b.SetBytes(int64(len(m)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = slab.Write(m)
+	}
+	b.StopTimer()
+	_ = slab.Close()
+}
+
+// --- Parallel contention benchmarks (hot path stress) ---
+// These benchmarks use high goroutine counts to expose cache-line
+// bouncing and synchronization overhead invisible in single-threaded tests.
+
+// BenchmarkParallelConcurrentSlabDiscard20G: 20 goroutines → slab → discard.
+func BenchmarkParallelConcurrentSlabDiscard20G(b *testing.B) {
+	slab := NewSlabWriter(discardWriter{}, 64*1024, 8)
+
+	b.SetBytes(int64(len(msg)))
+	b.SetParallelism(2) // GOMAXPROCS * 2 = ~20 goroutines on 10-core
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, _ = slab.Write(msg)
+		}
+	})
+	b.StopTimer()
+	_ = slab.Close()
+}
+
+// BenchmarkParallelConcurrentSlabTinySlab: N producers → tiny slab → discard.
+// Every Write triggers a slab swap (channel send + receive under mutex),
+// maximizing contention and exposing cache-line bouncing from atomic ops.
+func BenchmarkParallelConcurrentSlabTinySlab(b *testing.B) {
+	slab := NewSlabWriter(discardWriter{}, len(msg), 16) // slab = msg size
+
+	b.SetBytes(int64(len(msg)))
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, _ = slab.Write(msg)
+		}
+	})
+	b.StopTimer()
+	_ = slab.Close()
+}
+
+// BenchmarkParallelConcurrentSlabCachePressure: N producers → shared pool
+// work (simulates encoder) → slab → discard. The sync.Pool Get/Put and
+// buffer writes create cache pressure that amplifies atomic contention
+// inside slab.Write(). This is the pattern that caught the atomic.Int64
+// regression invisible in simpler benchmarks.
+func BenchmarkParallelConcurrentSlabCachePressure(b *testing.B) {
+	slab := NewSlabWriter(discardWriter{}, 64*1024, 8)
+	pool := &sync.Pool{New: func() any { b := make([]byte, 4096); return &b }}
+
+	b.SetBytes(int64(len(msg)))
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			bp := pool.Get().(*[]byte)
+			buf := *bp
+			copy(buf, msg) // simulate encode
+			_, _ = slab.Write(buf[:len(msg)])
+			pool.Put(bp)
+		}
+	})
+	b.StopTimer()
+	_ = slab.Close()
+}
+
+// BenchmarkParallelConcurrentSlabSlowIO20G: 20 goroutines → slab → slow writer.
+// Slow I/O increases mutex hold time in ioLoop, amplifying contention effects.
+func BenchmarkParallelConcurrentSlabSlowIO20G(b *testing.B) {
+	sw := &slowWriter{delay: 100 * time.Microsecond}
+	slab := NewSlabWriter(sw, 64*1024, 8)
+
+	b.SetBytes(int64(len(msg)))
+	b.SetParallelism(2)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, _ = slab.Write(msg)
+		}
+	})
+	b.StopTimer()
+	_ = slab.Close()
+	b.ReportMetric(float64(b.N)/float64(sw.writes), "msgs/write")
+}
+
+// --- Oversized message benchmarks ---
+
+// BenchmarkSlabBufferOversized1Pct: 99% normal + 1% oversized messages.
+func BenchmarkSlabBufferOversized1Pct(b *testing.B) {
+	slab := NewSlabWriter(discardWriter{}, 64*1024, 8)
+	bigMsg := make([]byte, 128*1024) // 2× slabSize
+
+	b.SetBytes(int64(len(msg)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if i%100 == 0 {
+			_, _ = slab.Write(bigMsg)
+		} else {
+			_, _ = slab.Write(msg)
+		}
+	}
+	b.StopTimer()
+	_ = slab.Close()
+}
+
+// BenchmarkSlabBufferOversized100Pct: 100% oversized messages.
+func BenchmarkSlabBufferOversized100Pct(b *testing.B) {
+	slab := NewSlabWriter(discardWriter{}, 64*1024, 8)
+	bigMsg := make([]byte, 128*1024) // 2× slabSize
+
+	b.SetBytes(int64(len(bigMsg)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = slab.Write(bigMsg)
+	}
+	b.StopTimer()
+	_ = slab.Close()
+}

--- a/slabwriter_test.go
+++ b/slabwriter_test.go
@@ -190,7 +190,7 @@ func TestSlabWriterDropOnFull(t *testing.T) {
 
 	_ = sb.Close()
 
-	assert.Greater(t, sb.Dropped(), int64(0), "expected some bytes to be dropped")
+	assert.Greater(t, sb.Stats().Dropped, int64(0), "expected some bytes to be dropped")
 }
 
 func TestSlabWriterDropOnFullCounter(t *testing.T) {
@@ -199,21 +199,135 @@ func TestSlabWriterDropOnFullCounter(t *testing.T) {
 	bw := &blockingWriter{ch: blocked}
 	sb := NewSlabWriter(bw, 16, 2, WithDropOnFull())
 
-	// Write 1: fills slab → swap checks pool (1 slab) → got it, send to full. OK.
-	// ioLoop picks from full, blocks on blockingWriter.Write.
+	// Write 1 (16 bytes): fills slab, no swap yet.
 	_, _ = sb.Write(make([]byte, 16))
-	// Write 2: fills slab → swap checks pool (empty) → DROP (16 bytes).
+	// Write 2 (16 bytes): avail=0 → swap → success (send full, get pool). pos=16.
+	// ioLoop picks slab, blocks on blockingWriter.
 	_, _ = sb.Write(make([]byte, 16))
-	// Write 3: fills slab (no swap yet — swap fires when NEXT write sees avail==0).
+	time.Sleep(10 * time.Millisecond)
+	// Write 3 (16 bytes): avail=0 → swap → send full ok (cap=2), pool empty → DROP.
+	// Abort (no torn write). pos=0.
 	_, _ = sb.Write(make([]byte, 16))
-	// Write 4: avail==0 → swap checks pool (empty) → DROP (16 bytes).
+	// Write 4 (16 bytes): pos=0, avail=16 → fits. No swap needed.
+	_, _ = sb.Write(make([]byte, 16))
+	// Write 5 (16 bytes): avail=0 → swap → pool still empty → DROP.
 	_, _ = sb.Write(make([]byte, 16))
 
-	assert.Equal(t, int64(2), sb.Dropped(), "expected 2 messages dropped")
+	// Write 3 drops 1 msg (itself). Write 5 drops 2 msgs (Write 4 + Write 5).
+	assert.Equal(t, int64(3), sb.Stats().Dropped, "expected 3 messages dropped")
 
 	// Unblock ioLoop and close.
 	close(blocked)
 	_ = sb.Close()
+}
+
+func TestSlabWriterDropCountsCurrentMessage(t *testing.T) {
+	// Regression: msgCount was incremented after the write loop,
+	// so the message that triggered the drop was not counted.
+	blocked := make(chan struct{})
+	bw := &blockingWriter{ch: blocked}
+	// slabSize=8, slabCount=2. One message fills one slab exactly.
+	sb := NewSlabWriter(bw, 8, 2, WithDropOnFull())
+
+	// Write 1 (8 bytes): fills slab. No swap yet (checked on next Write).
+	_, _ = sb.Write(make([]byte, 8))
+	// Write 2 (8 bytes): avail=0 → swapSlab → got free slab, send full.
+	// ioLoop picks it, blocks on blockingWriter. pos=8.
+	_, _ = sb.Write(make([]byte, 8))
+	time.Sleep(10 * time.Millisecond) // let ioLoop pick up the slab
+
+	// Write 3 (8 bytes): avail=0 → swapSlab → pool empty → DROP.
+	// Slab contains Write 2 (1 msg) + Write 3 incremented msgCount.
+	// With fix: msgCount=2 at drop time (both Write 2 and Write 3 counted).
+	_, _ = sb.Write(make([]byte, 8))
+
+	// Write 2's data is in the slab that got dropped (1 message).
+	// Write 3's data goes into the reused slab after drop.
+	// Before the fix (msgCount++ after loop), dropped was 0 because
+	// swapSlab saw msgCount=0. With the fix, dropped=1.
+	dropped := sb.Stats().Dropped
+	assert.Equal(t, int64(1), dropped, "the dropped slab's message must be counted")
+
+	close(blocked)
+	_ = sb.Close()
+}
+
+func TestSlabWriterDropOnFullNoTornWrite(t *testing.T) {
+	// A message larger than slabSize spans multiple slabs. If a drop
+	// happens mid-message, the destination receives a partial message
+	// (torn write).
+	blocked := make(chan struct{})
+	bw := &blockingWriter{ch: blocked}
+	// slabSize=8, slabCount=2. Message of 16 bytes spans 2 slabs.
+	sb := NewSlabWriter(bw, 8, 2, WithDropOnFull())
+
+	// Write 1 (8 bytes): fills slab, no swap yet.
+	_, _ = sb.Write(make([]byte, 8))
+	// Write 2 (8 bytes): avail=0 → swap → got free slab, send full.
+	// ioLoop picks it, blocks on blockingWriter.
+	_, _ = sb.Write(make([]byte, 8))
+	time.Sleep(10 * time.Millisecond) // let ioLoop pick up and block
+
+	// Write 3 (16 bytes): avail=0 → swap → pool empty → DROP first 8 bytes.
+	// Remaining 8 bytes go into reused slab — torn write.
+	_, _ = sb.Write(make([]byte, 16))
+
+	assert.True(t, sb.Stats().Dropped > 0, "expected drops")
+
+	// Unblock and close.
+	close(blocked)
+	_ = sb.Close()
+
+	t.Logf("dropped=%d (torn write: second half was written to destination)", sb.Stats().Dropped)
+}
+
+func TestSlabWriterMessagesAlwaysComplete(t *testing.T) {
+	// Every message written to destination must be complete — no partial
+	// writes, even under high contention with early swaps.
+	cw := &collectWriter{}
+	// Small slabs to force frequent early swaps.
+	sb := NewSlabWriter(cw, 64, 4)
+
+	msgs := []string{
+		"aaaa-msg-01-end\n", // 16 bytes
+		"bbbb-msg-02-end\n",
+		"cccc-msg-03-end\n",
+		"dddd-msg-04-end\n",
+		"eeee-msg-05-end\n",
+		"ffff-msg-06-end\n",
+		"gggg-msg-07-end\n",
+		"hhhh-msg-08-end\n",
+		"iiii-msg-09-end\n",
+		"jjjj-msg-10-end\n",
+	}
+
+	for _, m := range msgs {
+		_, _ = sb.Write([]byte(m))
+	}
+	_ = sb.Close()
+
+	data := cw.allData()
+	for _, m := range msgs {
+		assert.Contains(t, data, m, "message must appear complete in output")
+	}
+}
+
+func TestSlabWriterOversizedMessageComplete(t *testing.T) {
+	// Oversized messages (> slabSize) must arrive complete at destination.
+	cw := &collectWriter{}
+	sb := NewSlabWriter(cw, 16, 4) // tiny slabs
+
+	small := "small\n"
+	big := "this-is-a-big-message-that-exceeds-slab-size\n" // 46 bytes > 16
+
+	_, _ = sb.Write([]byte(small))
+	_, _ = sb.Write([]byte(big))
+	_, _ = sb.Write([]byte(small))
+	_ = sb.Close()
+
+	data := cw.allData()
+	assert.Contains(t, data, small)
+	assert.Contains(t, data, big, "oversized message must appear complete")
 }
 
 func TestSlabWriterNoDropWhenKeepingUp(t *testing.T) {
@@ -225,7 +339,7 @@ func TestSlabWriterNoDropWhenKeepingUp(t *testing.T) {
 	}
 	_ = sb.Close()
 
-	assert.Equal(t, int64(0), sb.Dropped())
+	assert.Equal(t, int64(0), sb.Stats().Dropped)
 	assert.Contains(t, cw.allData(), "msg")
 }
 
@@ -250,7 +364,7 @@ func TestSlabWriterDropOnFullNonBlocking(t *testing.T) {
 		t.Fatal("producer blocked for >1s — WithDropOnFull should prevent this")
 	}
 
-	assert.Greater(t, sb.Dropped(), int64(0))
+	assert.Greater(t, sb.Stats().Dropped, int64(0))
 
 	close(blocked)
 	_ = sb.Close()
@@ -285,4 +399,108 @@ func TestSlabWriterFlushPartialNoDeadlock(t *testing.T) {
 		t.Fatal("deadlock: producer blocked for >3s")
 	}
 	require.NoError(t, sw.Close())
+}
+
+// panicWriter panics on every Write — simulates a broken destination.
+type panicWriter struct{}
+
+func (panicWriter) Write([]byte) (int, error) { panic("destination exploded") }
+func (panicWriter) Flush() error              { return nil }
+func (panicWriter) Sync() error               { return nil }
+
+// panicOnWrite panics when written to — simulates a broken errW.
+type panicOnWrite struct{}
+
+func (panicOnWrite) Write([]byte) (int, error) { panic("errW exploded") }
+
+func TestSlabWriterErrWriterPanicDoesNotCrashIoLoop(t *testing.T) {
+	// Setup: destination panics on Write, errW also panics when
+	// reportError tries to log the error. This should NOT crash ioLoop.
+	sw := NewSlabWriter(panicWriter{}, 64, 2,
+		WithErrorWriter(panicOnWrite{}),
+	)
+
+	// Write enough to fill a slab and trigger ioLoop processing.
+	_, _ = sw.Write(make([]byte, 64))
+
+	// If ioLoop crashed, Close will hang (done channel never closed).
+	done := make(chan error, 1)
+	go func() { done <- sw.Close() }()
+
+	select {
+	case <-done:
+		// ioLoop survived — test passes.
+	case <-time.After(3 * time.Second):
+		t.Fatal("ioLoop appears dead — Close hung (errW panic crashed ioLoop)")
+	}
+}
+
+func TestSlabWriterEarlySwapKeepsMessageIntact(t *testing.T) {
+	// Message fits in slabSize but not in remaining space.
+	// Early swap should keep it in one slab.
+	cw := &collectWriter{}
+	sb := NewSlabWriter(cw, 16, 4)
+
+	// Fill 12 bytes of slab. 4 bytes remain.
+	_, _ = sb.Write([]byte("aaaaaaaaaaaa")) // 12 bytes
+	// Write 10 bytes — doesn't fit in 4 remaining, triggers early swap.
+	_, _ = sb.Write([]byte("bbbbbbbbbb")) // 10 bytes
+
+	_ = sb.Close()
+	assert.Equal(t, "aaaaaaaaaaaabbbbbbbbbb", cw.allData())
+}
+
+func TestSlabWriterOversizedWrite(t *testing.T) {
+	// Message larger than slabSize uses dedicated oversized slab.
+	cw := &collectWriter{}
+	sb := NewSlabWriter(cw, 8, 4)
+
+	_, _ = sb.Write([]byte("before"))
+	_, _ = sb.Write([]byte("oversized-message-larger-than-slab")) // 34 bytes > 8
+	_, _ = sb.Write([]byte("after"))
+
+	_ = sb.Close()
+	assert.Equal(t, "beforeoversized-message-larger-than-slabafter", cw.allData())
+}
+
+func TestSlabWriterOversizedDropOnFull(t *testing.T) {
+	// Oversized message with dropOnFull — entire message dropped atomically.
+	blocked := make(chan struct{})
+	bw := &blockingWriter{ch: blocked}
+	sb := NewSlabWriter(bw, 8, 2, WithDropOnFull())
+
+	// Fill and send first slab, ioLoop blocks.
+	_, _ = sb.Write(make([]byte, 8))
+	_, _ = sb.Write(make([]byte, 8)) // triggers swap, sends to full
+	time.Sleep(10 * time.Millisecond)
+
+	// Oversized write — pool empty, should drop entirely.
+	_, _ = sb.Write(make([]byte, 20))
+
+	assert.True(t, sb.Stats().Dropped > 0, "oversized message should be dropped")
+
+	close(blocked)
+	_ = sb.Close()
+}
+
+func TestSlabWriterEarlySwapDropOnFull(t *testing.T) {
+	// Message fits in slabSize but not in remaining space.
+	// Early swap with dropOnFull — entire message dropped.
+	blocked := make(chan struct{})
+	bw := &blockingWriter{ch: blocked}
+	sb := NewSlabWriter(bw, 16, 2, WithDropOnFull())
+
+	_, _ = sb.Write(make([]byte, 12)) // 12 bytes, 4 remain
+	// Swap succeeds, ioLoop picks up and blocks.
+	_, _ = sb.Write(make([]byte, 16)) // triggers swap (early: 16 > 4)
+	time.Sleep(10 * time.Millisecond)
+
+	// Next write: 10 bytes, 0 remain → early swap → pool empty → drop.
+	_, _ = sb.Write(make([]byte, 16))
+	_, _ = sb.Write(make([]byte, 10))
+
+	assert.True(t, sb.Stats().Dropped > 0, "expected drops on early swap")
+
+	close(blocked)
+	_ = sb.Close()
 }

--- a/writerslot.go
+++ b/writerslot.go
@@ -1,0 +1,132 @@
+package logf
+
+import (
+	"io"
+	"sync"
+	"sync/atomic"
+)
+
+// NewWriterSlot returns a new WriterSlot. By default, writes before
+// Set are silently dropped.
+func NewWriterSlot(opts ...WriterSlotOption) *WriterSlot {
+	s := &WriterSlot{}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+// WriterSlot is a placeholder Writer that can be connected to a real
+// writer later via Set. Before Set is called, writes are either dropped
+// or buffered (if WithSlotBuffer was used).
+//
+// WriterSlot implements Writer (io.Writer + Flush + Sync) and is safe
+// for concurrent use. Use it when the destination is not available at
+// logger creation time:
+//
+//	slot := logf.NewWriterSlot()
+//	logger := logf.NewLogger().Output(slot).Build()
+//	// ... later, when destination is ready:
+//	slot.Set(file)
+//
+// Set is NOT safe for concurrent calls — call it from a single goroutine.
+type WriterSlot struct {
+	w       atomic.Pointer[writerRef]
+	flushed atomic.Bool
+	mu      sync.Mutex // protects buf
+	buf     []byte
+	bufSize int
+}
+
+// writerRef wraps Writer to avoid double indirection through atomic.Pointer.
+type writerRef struct{ w Writer }
+
+// WriterSlotOption configures a WriterSlot.
+type WriterSlotOption func(*WriterSlot)
+
+// WithSlotBuffer enables buffering of writes before Set is called.
+// Up to size bytes are kept in memory. Writes that do not fit entirely
+// are dropped (no partial writes). The buffer is flushed to the real
+// writer on the first Write after Set.
+func WithSlotBuffer(size int) WriterSlotOption {
+	return func(s *WriterSlot) {
+		if size > 0 {
+			s.bufSize = size
+			s.buf = make([]byte, 0, size)
+		}
+	}
+}
+
+// Write writes p to the underlying writer if Set has been called.
+// Before Set, data is buffered (if configured) or dropped.
+func (s *WriterSlot) Write(p []byte) (int, error) {
+	if ref := s.w.Load(); ref != nil {
+		if s.bufSize > 0 && !s.flushed.Load() {
+			s.flushPending(ref.w)
+		}
+		return ref.w.Write(p)
+	}
+
+	// No writer yet — buffer or drop.
+	if s.bufSize > 0 {
+		s.mu.Lock()
+		if s.buf != nil {
+			if len(p) <= s.bufSize-len(s.buf) {
+				s.buf = append(s.buf, p...)
+			}
+			// else: doesn't fit entirely — drop
+		}
+		s.mu.Unlock()
+	}
+
+	return len(p), nil
+}
+
+// flushPending writes the pre-Set buffer to w under the mutex.
+// All concurrent Write calls block until the buffer is flushed,
+// guaranteeing that buffered data appears before any post-Set writes.
+// This happens at most once per WriterSlot lifetime.
+func (s *WriterSlot) flushPending(w Writer) {
+	s.mu.Lock()
+	buf := s.buf
+	if buf == nil {
+		s.mu.Unlock()
+		return
+	}
+	if len(buf) > 0 {
+		_, _ = w.Write(buf)
+		_ = w.Flush()
+	}
+	s.buf = nil
+	s.flushed.Store(true)
+	s.mu.Unlock()
+}
+
+// Flush delegates to the underlying writer's Flush. No-op before Set.
+func (s *WriterSlot) Flush() error {
+	if ref := s.w.Load(); ref != nil {
+		return ref.w.Flush()
+	}
+	return nil
+}
+
+// Sync delegates to the underlying writer's Sync. No-op before Set.
+func (s *WriterSlot) Sync() error {
+	if ref := s.w.Load(); ref != nil {
+		return ref.w.Sync()
+	}
+	return nil
+}
+
+// Set connects the slot to a real writer. The buffered data (if any)
+// will be flushed on the first Write call after Set — this preserves
+// temporal ordering without blocking Set itself.
+//
+// The writer is wrapped via WriterFromIO if needed.
+// Set is NOT safe for concurrent calls.
+func (s *WriterSlot) Set(w io.Writer) {
+	prev := s.w.Swap(&writerRef{WriterFromIO(w)})
+	if prev != nil {
+		_ = prev.w.Sync()
+	}
+}

--- a/writerslot_test.go
+++ b/writerslot_test.go
@@ -1,0 +1,226 @@
+package logf
+
+import (
+	"bytes"
+	"errors"
+	"sync"
+	"testing"
+)
+
+func TestWriterSlotDropBeforeSet(t *testing.T) {
+	slot := NewWriterSlot()
+	n, err := slot.Write([]byte("dropped"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 7 {
+		t.Fatalf("got %d, want 7", n)
+	}
+
+	var buf bytes.Buffer
+	slot.Set(&buf)
+
+	_, _ = slot.Write([]byte("hello"))
+	if buf.String() != "hello" {
+		t.Fatalf("got %q, want %q", buf.String(), "hello")
+	}
+}
+
+func TestWriterSlotBufferBeforeSet(t *testing.T) {
+	slot := NewWriterSlot(WithSlotBuffer(1024))
+	_, _ = slot.Write([]byte("early1\n"))
+	_, _ = slot.Write([]byte("early2\n"))
+
+	var buf bytes.Buffer
+	slot.Set(&buf)
+
+	_, _ = slot.Write([]byte("late\n"))
+
+	want := "early1\nearly2\nlate\n"
+	if buf.String() != want {
+		t.Fatalf("got %q, want %q", buf.String(), want)
+	}
+}
+
+func TestWriterSlotBufferOverflow(t *testing.T) {
+	slot := NewWriterSlot(WithSlotBuffer(10))
+	_, _ = slot.Write([]byte("12345"))    // 5 bytes, fits
+	_, _ = slot.Write([]byte("67890"))    // 5 bytes, fits exactly
+	_, _ = slot.Write([]byte("overflow")) // 8 bytes, doesn't fit — dropped entirely
+
+	var buf bytes.Buffer
+	slot.Set(&buf)
+	_, _ = slot.Write([]byte("trigger")) // triggers flush of buffered data
+
+	want := "1234567890trigger"
+	if buf.String() != want {
+		t.Fatalf("got %q, want %q", buf.String(), want)
+	}
+}
+
+func TestWriterSlotSetSwap(t *testing.T) {
+	slot := NewWriterSlot()
+
+	var buf1, buf2 bytes.Buffer
+	slot.Set(&buf1)
+	_, _ = slot.Write([]byte("first"))
+
+	slot.Set(&buf2)
+	_, _ = slot.Write([]byte("second"))
+
+	if buf1.String() != "first" {
+		t.Fatalf("buf1: got %q, want %q", buf1.String(), "first")
+	}
+	if buf2.String() != "second" {
+		t.Fatalf("buf2: got %q, want %q", buf2.String(), "second")
+	}
+}
+
+func TestWriterSlotFlushSync(t *testing.T) {
+	slot := NewWriterSlot()
+
+	// Before Set — no-op.
+	if err := slot.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	if err := slot.Sync(); err != nil {
+		t.Fatal(err)
+	}
+
+	// After Set — delegates.
+	w := &trackingWriter{}
+	slot.Set(w)
+
+	_ = slot.Flush()
+	if !w.flushed {
+		t.Error("Flush not delegated")
+	}
+	_ = slot.Sync()
+	if !w.synced {
+		t.Error("Sync not delegated")
+	}
+}
+
+func TestWriterSlotWriteError(t *testing.T) {
+	slot := NewWriterSlot()
+	errBroken := errors.New("broken")
+	slot.Set(&failWriter{err: errBroken})
+
+	_, err := slot.Write([]byte("data"))
+	if !errors.Is(err, errBroken) {
+		t.Fatalf("got %v, want %v", err, errBroken)
+	}
+}
+
+type safeBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *safeBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *safeBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func TestWriterSlotConcurrent(t *testing.T) {
+	slot := NewWriterSlot(WithSlotBuffer(4096))
+	var wg sync.WaitGroup
+
+	// Writers before Set.
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				_, _ = slot.Write([]byte("x"))
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	buf := &safeBuffer{}
+	slot.Set(buf)
+
+	// Writers after Set.
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				_, _ = slot.Write([]byte("y"))
+			}
+		}()
+	}
+	wg.Wait()
+
+	data := buf.String()
+	yCount := 0
+	for _, c := range data {
+		if c == 'y' {
+			yCount++
+		}
+	}
+	if yCount != 1000 {
+		t.Fatalf("got %d y's, want 1000", yCount)
+	}
+}
+
+func TestWriterSlotConcurrentSetAndWrite(t *testing.T) {
+	// Set is called while Write goroutines are active.
+	// No panics, no data races. Some writes may be dropped (pre-Set).
+	slot := NewWriterSlot(WithSlotBuffer(4096))
+	buf := &safeBuffer{}
+	var wg sync.WaitGroup
+
+	// Start writers immediately.
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 1000; j++ {
+				_, _ = slot.Write([]byte("w"))
+			}
+		}()
+	}
+
+	// Set while writers are running.
+	slot.Set(buf)
+
+	wg.Wait()
+
+	// At least some writes should have reached the buffer.
+	data := buf.String()
+	if len(data) == 0 {
+		t.Fatal("no writes reached the writer")
+	}
+	for _, c := range data {
+		if c != 'w' && c != 'x' {
+			t.Fatalf("unexpected byte %q in output", c)
+		}
+	}
+}
+
+// --- test helpers ---
+
+type trackingWriter struct {
+	flushed bool
+	synced  bool
+}
+
+func (w *trackingWriter) Write(p []byte) (int, error) { return len(p), nil }
+func (w *trackingWriter) Flush() error                { w.flushed = true; return nil }
+func (w *trackingWriter) Sync() error                 { w.synced = true; return nil }
+
+type failWriter struct{ err error }
+
+func (w *failWriter) Write([]byte) (int, error) { return 0, w.err }
+func (w *failWriter) Flush() error              { return w.err }
+func (w *failWriter) Sync() error               { return w.err }


### PR DESCRIPTION
WriterSlot:
- Placeholder Writer connectable later via Set for lazy initialization
- Optional pre-Set buffering (WithSlotBuffer), writes flushed on first Write after Set under mutex to preserve ordering
- Implements full Writer interface (Write/Flush/Sync)
- Race-safe: atomic pointer for hot path, mutex only for pending flush

SlabWriter message integrity:
- Early swap: messages that don't fit in remaining slab space trigger swap before writing, keeping each message in a single slab
- Oversized messages (> slabSize) use dedicated buffer sent as one unit, discarded after write (not returned to pool)
- Drop atomicity: in dropOnFull mode, messages are fully delivered or fully dropped — no torn writes for any message size

SlabWriter fixes:
- errW panic no longer crashes ioLoop (safeReport with recover)
- Drop counter includes the current message (msgCount++ before loop)

README:
- Updated slogan and features section
- Added slog integration details (Logger.Slog() inheritance)