### PR TITLE
fix: update badges, add Codecov token to CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,6 +22,8 @@ jobs:
     - run: go test -race -coverprofile=coverage.out ./...
     - uses: codecov/codecov-action@v5
       if: matrix.go == '1.23.x'
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   lint:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # logf
 
-[![GoDoc](https://godoc.org/github.com/ssgreg/logf?status.svg)](https://godoc.org/github.com/ssgreg/logf)
+[![Go Reference](https://pkg.go.dev/badge/github.com/ssgreg/logf/v2.svg)](https://pkg.go.dev/github.com/ssgreg/logf/v2)
 [![Build Status](https://github.com/ssgreg/logf/actions/workflows/go.yml/badge.svg)](https://github.com/ssgreg/logf/actions/workflows/go.yml)
-[![Go Report Status](https://goreportcard.com/badge/github.com/ssgreg/logf)](https://goreportcard.com/report/github.com/ssgreg/logf)
-[![Coverage Status](https://codecov.io/gh/ssgreg/logf/branch/master/graph/badge.svg)](https://codecov.io/gh/ssgreg/logf)
+[![Go Report Card](https://goreportcard.com/badge/github.com/ssgreg/logf/v2)](https://goreportcard.com/report/github.com/ssgreg/logf/v2)
+[![codecov](https://codecov.io/gh/ssgreg/logf/branch/master/graph/badge.svg)](https://codecov.io/gh/ssgreg/logf)
 
 Structured logging for Go — context-aware, slog-native, fast.
 


### PR DESCRIPTION
- Replace godoc.org badge with pkg.go.dev
- Update Go Report Card to v2 module path
- Add Codecov badge
- Add CODECOV_TOKEN to codecov-action