### PR TITLE
fix(examples): correct output comments, mention hl log viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,18 @@ rotator := &lumberjack.Logger{
 sw := logf.NewSlabWriter(rotator).SlabSize(64*1024).SlabCount(8).Build()
 ```
 
+### Viewing JSON logs
+
+JSON is great for machines but hard on the eyes. [hl](https://github.com/pamburus/hl)
+is a log viewer that renders JSON logs with colors, field highlighting, and
+filtering — similar to logf's text encoder but for any JSON log file:
+
+```bash
+hl app.log                     # colored, human-readable
+hl app.log -f 'level == error' # filter by level
+tail -f app.log | hl           # live streaming
+```
+
 ## Performance
 
 Parallel benchmarks on Apple M1 Pro, Go 1.24, `count=5`.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Two lines to logging:
 ```go
 logger := logf.NewLogger().Build()
 logger.Info(ctx, "hello, world", logf.String("from", "logf"))
-// → {"level":"info","ts":"2026-03-19T14:04:02Z","caller":"main.go:10","msg":"hello, world","from":"logf"}
+// → {"level":"info","ts":"2026-03-19T14:04:02Z","msg":"hello, world","caller":"main.go:10","from":"logf"}
 ```
 
 Want colors? Say no more:

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -19,7 +19,7 @@ func main() {
 	// First output shown in full; subsequent outputs omit "ts" and "caller" for brevity.
 
 	logger.Debug(ctx, "starting up")
-	// → {"level":"debug","ts":"2025-01-15T12:00:00Z","caller":"basic/main.go:21","msg":"starting up"}
+	// → {"level":"debug","ts":"2025-01-15T12:00:00Z","msg":"starting up","caller":"basic/main.go:21"}
 
 	logger.Info(ctx, "request handled", logf.String("method", "GET"), logf.Int("status", 200))
 	// → {"level":"info",..,"msg":"request handled","method":"GET","status":200}

--- a/examples/slog/main.go
+++ b/examples/slog/main.go
@@ -57,5 +57,5 @@ func thirdPartyLibrary(logger *slog.Logger, ctx context.Context) {
 	// The library doesn't know about logf, but context fields
 	// (request_id) appear in its logs automatically.
 	logger.InfoContext(ctx, "query executed", "rows", 42)
-	// → {"logger":"db","msg":"query executed","component":"postgres","request_id":"abc-123","rows":42}
+	// → {"logger":"db","msg":"query executed","request_id":"abc-123","component":"postgres","rows":42}
 }


### PR DESCRIPTION
## Summary

- Fix field order in example output comments (caller after msg, context fields before accumulated)
- Fix same field order in README getting-started snippet  
- Mention [hl](https://github.com/pamburus/hl) log viewer for JSON logs

Follow-up to #51.

## Test plan

- [x] All examples produce output matching their comments