### PR TITLE
feat: add contextless logging methods (Debugx, Infox, Warnx, Errorx) and nil ctx support

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -40,7 +40,11 @@ type Logger struct {
 
 // Enabled reports whether logging at the given level would actually produce
 // output. Use this to guard expensive argument preparation.
+// A nil ctx is treated as context.Background().
 func (l *Logger) Enabled(ctx context.Context, lvl Level) bool {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	return l.w.Enabled(ctx, lvl)
 }
 
@@ -50,7 +54,11 @@ type LogFunc func(context.Context, string, ...Field)
 // AtLevel calls fn only if the specified level is enabled, passing it a
 // LogFunc pre-bound to that level. This is perfect for guarding expensive
 // log preparation without a separate Enabled check.
+// A nil ctx is treated as context.Background().
 func (l *Logger) AtLevel(ctx context.Context, lvl Level, fn func(LogFunc)) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if !l.w.Enabled(ctx, lvl) {
 		return
 	}
@@ -139,7 +147,11 @@ func (l *Logger) WithGroup(name string) *Logger {
 
 // Debug logs a message at LevelDebug. If debug logging is disabled, this
 // is a no-op — no fields are evaluated, no allocations happen.
+// A nil ctx is treated as context.Background().
 func (l *Logger) Debug(ctx context.Context, text string, fs ...Field) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if !l.w.Enabled(ctx, LevelDebug) {
 		return
 	}
@@ -149,7 +161,11 @@ func (l *Logger) Debug(ctx context.Context, text string, fs ...Field) {
 
 // Info logs a message at LevelInfo. This is the default "something
 // happened" level for normal operational events.
+// A nil ctx is treated as context.Background().
 func (l *Logger) Info(ctx context.Context, text string, fs ...Field) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if !l.w.Enabled(ctx, LevelInfo) {
 		return
 	}
@@ -159,7 +175,11 @@ func (l *Logger) Info(ctx context.Context, text string, fs ...Field) {
 
 // Warn logs a message at LevelWarn. Use this for situations that are
 // unexpected but not broken — things a human should probably look at.
+// A nil ctx is treated as context.Background().
 func (l *Logger) Warn(ctx context.Context, text string, fs ...Field) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if !l.w.Enabled(ctx, LevelWarn) {
 		return
 	}
@@ -169,7 +189,11 @@ func (l *Logger) Warn(ctx context.Context, text string, fs ...Field) {
 
 // Error logs a message at LevelError. Something went wrong and you want
 // everyone to know about it.
+// A nil ctx is treated as context.Background().
 func (l *Logger) Error(ctx context.Context, text string, fs ...Field) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if !l.w.Enabled(ctx, LevelError) {
 		return
 	}
@@ -179,12 +203,60 @@ func (l *Logger) Error(ctx context.Context, text string, fs ...Field) {
 
 // Log logs a message at an arbitrary level. Use this when the level is
 // determined at runtime; for the common cases prefer Debug/Info/Warn/Error.
+// A nil ctx is treated as context.Background().
 func (l *Logger) Log(ctx context.Context, lvl Level, text string, fs ...Field) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if !l.w.Enabled(ctx, lvl) {
 		return
 	}
 
 	l.write(ctx, 1, lvl, text, fs)
+}
+
+// Debugx is like Debug but without a context parameter.
+// Equivalent to Debug(context.Background(), text, fs...).
+func (l *Logger) Debugx(text string, fs ...Field) {
+	ctx := context.Background()
+	if !l.w.Enabled(ctx, LevelDebug) {
+		return
+	}
+
+	l.write(ctx, 1, LevelDebug, text, fs)
+}
+
+// Infox is like Info but without a context parameter.
+// Equivalent to Info(context.Background(), text, fs...).
+func (l *Logger) Infox(text string, fs ...Field) {
+	ctx := context.Background()
+	if !l.w.Enabled(ctx, LevelInfo) {
+		return
+	}
+
+	l.write(ctx, 1, LevelInfo, text, fs)
+}
+
+// Warnx is like Warn but without a context parameter.
+// Equivalent to Warn(context.Background(), text, fs...).
+func (l *Logger) Warnx(text string, fs ...Field) {
+	ctx := context.Background()
+	if !l.w.Enabled(ctx, LevelWarn) {
+		return
+	}
+
+	l.write(ctx, 1, LevelWarn, text, fs)
+}
+
+// Errorx is like Error but without a context parameter.
+// Equivalent to Error(context.Background(), text, fs...).
+func (l *Logger) Errorx(text string, fs ...Field) {
+	ctx := context.Background()
+	if !l.w.Enabled(ctx, LevelError) {
+		return
+	}
+
+	l.write(ctx, 1, LevelError, text, fs)
 }
 
 func (l *Logger) write(ctx context.Context, extraSkip int, lv Level, text string, fs []Field) {

--- a/logger_test.go
+++ b/logger_test.go
@@ -329,6 +329,68 @@ func TestLoggerSlogNoName(t *testing.T) {
 	assert.Equal(t, "", sink.Entry.LoggerName)
 }
 
+func TestContextlessMethods(t *testing.T) {
+	w := &testHandler{}
+	logger := New(w).WithCaller(false)
+
+	logger.Debugx("debug", String("k", "v"))
+	logger.Infox("info")
+	logger.Warnx("warn")
+	logger.Errorx("error")
+
+	require.Equal(t, 4, len(w.Entries))
+	assert.Equal(t, "debug", w.Entries[0].Text)
+	assert.Equal(t, LevelDebug, w.Entries[0].Level)
+	assert.Equal(t, "info", w.Entries[1].Text)
+	assert.Equal(t, LevelInfo, w.Entries[1].Level)
+	assert.Equal(t, "warn", w.Entries[2].Text)
+	assert.Equal(t, LevelWarn, w.Entries[2].Level)
+	assert.Equal(t, "error", w.Entries[3].Text)
+	assert.Equal(t, LevelError, w.Entries[3].Level)
+
+	// Fields are passed through.
+	require.Equal(t, 1, len(w.Entries[0].Fields))
+	assert.Equal(t, "k", w.Entries[0].Fields[0].Key)
+
+	// Disabled level: nothing logged.
+	w2 := newLeveledTestHandler(LevelError)
+	logger2 := New(w2).WithCaller(false)
+
+	logger2.Debugx("nope")
+	logger2.Infox("nope")
+	logger2.Warnx("nope")
+	assert.Equal(t, 0, len(w2.Entries))
+
+	logger2.Errorx("yes")
+	require.Equal(t, 1, len(w2.Entries))
+	assert.Equal(t, "yes", w2.Entries[0].Text)
+}
+
+func TestNilContext(t *testing.T) {
+	w := &testHandler{}
+	logger := New(w).WithCaller(false)
+
+	// Use a typed nil to avoid SA1012 lint warnings.
+	// We intentionally test nil ctx support here.
+	var noCtx context.Context
+
+	logger.Debug(noCtx, "debug", String("k", "v"))
+	logger.Info(noCtx, "info")
+	logger.Warn(noCtx, "warn")
+	logger.Error(noCtx, "error")
+	logger.Log(noCtx, LevelInfo, "log")
+	logger.AtLevel(noCtx, LevelInfo, func(log LogFunc) {
+		log(noCtx, "at-level")
+	})
+
+	require.Equal(t, 6, len(w.Entries))
+	assert.Equal(t, "debug", w.Entries[0].Text)
+	assert.Equal(t, "at-level", w.Entries[5].Text)
+
+	// Enabled must not panic with nil context.
+	assert.True(t, logger.Enabled(noCtx, LevelInfo))
+}
+
 func TestContext(t *testing.T) {
 	// Check if no logger is associated with the Context — returns DisabledLogger.
 	assert.Equal(t, DisabledLogger(), FromContext(context.Background()))


### PR DESCRIPTION
Logger methods now accept nil context, treating it as context.Background(). New Infox/Debugx/Warnx/Errorx methods provide a shorter API when context is not available (main, init, tests).